### PR TITLE
fix get_presigned_object_url() API to use host header value

### DIFF
--- a/src/s3/client.rs
+++ b/src/s3/client.rs
@@ -2193,7 +2193,7 @@ impl<'a> Client<'a> {
 
             presign_v4(
                 &args.method,
-                &url.host,
+                &url.host_header_value(),
                 &url.path,
                 &region,
                 &mut query_params,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -567,7 +567,7 @@ impl<'a> ClientTest<'_> {
         };
 
         let spawned_task = task::spawn(listen_task());
-        task::sleep(std::time::Duration::from_millis(100)).await;
+        task::sleep(std::time::Duration::from_millis(200)).await;
 
         let size = 16_usize;
         self.client


### PR DESCRIPTION
Fixes #46