### PR TITLE
Add builder style constructor for Client

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         cargo fmt --all -- --check
         cargo clippy --all-targets --all-features -- -A clippy::result_large_err -A clippy::type_complexity -A clippy::too_many_arguments
-        cargo build --verbose
+        cargo build --bins --examples --tests --benches --verbose
 
     - name: Run tests
       run: |


### PR DESCRIPTION
Builder style makes it easier to construct the Client because each setting is done via a separate function thus documenting the purpose the setting.

Ref: https://rust-lang.github.io/api-guidelines/type-safety.html#builders-enable-construction-of-complex-values-c-builder