### PR TITLE
Fix list objects xml parsing bug and improve perf.

### DIFF
--- a/src/s3/error.rs
+++ b/src/s3/error.rs
@@ -52,8 +52,8 @@ impl ErrorResponse {
     }
 }
 
-#[derive(Debug)]
 /// Error definitions
+#[derive(Debug)]
 pub enum Error {
     TimeParseError(chrono::ParseError),
     InvalidUrl(http::uri::InvalidUri),


### PR DESCRIPTION
For list-object-versions there was a bug that would return delete
markers after all versions of an object. The server response contains
the order of versions and delete markers according to recency and the
list objects client call should preserve this. This is fixed in this
change.

XML parsing was using the `take_child` call, that mutates a vector
removing an element in it. For a response containing N items, using
take_child on item, causes the XML parsing cost to be O(N^2) (so 1
million operations for a 1000 item list) - this change makes the parsing
cost linear.