### PR TITLE
Remove dynamically dispatched fields

### DIFF
--- a/examples/file-uploader.rs
+++ b/examples/file-uploader.rs
@@ -2,6 +2,7 @@ use minio::s3::args::{BucketExistsArgs, MakeBucketArgs, UploadObjectArgs};
 use minio::s3::client::Client;
 use minio::s3::creds::StaticProvider;
 use minio::s3::http::BaseUrl;
+use minio::s3::sse::SseCustomerKey;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -41,7 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // 'asiaphotos-2015.zip' to bucket 'asiatrip'.
     client
         .upload_object(
-            &mut UploadObjectArgs::new(
+            &mut UploadObjectArgs::<SseCustomerKey>::new(
                 &bucket_name,
                 "asiaphotos-2015.zip",
                 "/home/user/Photos/asiaphotos.zip",

--- a/src/s3/args.rs
+++ b/src/s3/args.rs
@@ -517,7 +517,7 @@ impl<'a, S: Sse> PutObjectApiArgs<'a, S> {
     /// ```
     /// use minio::s3::args::*;
     /// let data: &[u8] = &[65, 67, 69];
-    /// let args = PutObjectApiArgs::new("my-bucket", "my-object", data).unwrap();
+    /// let args = PutObjectApiArgs::<S>::new("my-bucket", "my-object", data).unwrap();
     /// ```
     pub fn new(
         bucket_name: &'a str,
@@ -592,7 +592,7 @@ impl<'a, S: Sse> UploadPartArgs<'a, S> {
     /// ```
     /// use minio::s3::args::*;
     /// let data: &[u8] = &[65, 67, 69];
-    /// let args = UploadPartArgs::new(
+    /// let args = UploadPartArgs::<S>::new(
     ///     "my-bucket",
     ///     "my-object",
     ///     "c53a2b73-f5e6-484a-9bc0-09cce13e8fd0",
@@ -697,8 +697,7 @@ impl<'a, R: std::io::Read, S: Sse> PutObjectArgs<'a, R, S> {
     ///   let meta = std::fs::metadata(filename).unwrap();
     ///   let object_size = Some(meta.len() as usize);
     ///   let mut file = File::open(filename).unwrap();
-    ///   let args = PutObjectArgs::new("my-bucket", "my-object", &mut file, object_size, None).unwrap();
-    /// ...
+    ///   let args = PutObjectArgs::<R,S>::new("my-bucket", "my-object", &mut file, object_size, None).unwrap();
     /// ```
     pub fn new(
         bucket_name: &'a str,
@@ -1469,7 +1468,7 @@ impl<'a, S: Sse> CopyObjectArgs<'a, S> {
     /// ```
     /// use minio::s3::args::*;
     /// let src = CopySource::new("my-src-bucket", "my-src-object").unwrap();
-    /// let args = CopyObjectArgs::new("my-bucket", "my-object", src).unwrap();
+    /// let args = CopyObjectArgs::<S>::new("my-bucket", "my-object", src).unwrap();
     /// ```
     pub fn new(
         bucket_name: &'a str,
@@ -1698,7 +1697,7 @@ impl<'a, S: Sse> ComposeObjectArgs<'a, S> {
     /// let mut sources: Vec<ComposeSource> = Vec::new();
     /// sources.push(ComposeSource::new("my-src-bucket", "my-src-object-1").unwrap());
     /// sources.push(ComposeSource::new("my-src-bucket", "my-src-object-2").unwrap());
-    /// let args = ComposeObjectArgs::new("my-bucket", "my-object", &mut sources).unwrap();
+    /// let args = ComposeObjectArgs::<S>::new("my-bucket", "my-object", &mut sources).unwrap();
     /// ```
     pub fn new(
         bucket_name: &'a str,
@@ -2711,7 +2710,7 @@ impl<'a, S: Sse> UploadObjectArgs<'a, S> {
     ///
     /// ```no_run
     /// use minio::s3::args::*;
-    /// let args = UploadObjectArgs::new("my-bucket", "my-object", "asiaphotos-2015.zip").unwrap();
+    /// let args = UploadObjectArgs::<S>::new("my-bucket", "my-object", "asiaphotos-2015.zip").unwrap();
     /// ```
     pub fn new(
         bucket_name: &'a str,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -16,6 +16,7 @@
 use async_std::task;
 use chrono::Duration;
 use hyper::http::Method;
+use minio::s3::sse::SseCustomerKey;
 use minio::s3::types::NotificationRecords;
 use rand::distributions::{Alphanumeric, DistString};
 use sha2::{Digest, Sha256};
@@ -186,7 +187,7 @@ impl ClientTest {
         let size = 16_usize;
         self.client
             .put_object(
-                &mut PutObjectArgs::new(
+                &mut PutObjectArgs::<RandReader, SseCustomerKey>::new(
                     &self.test_bucket,
                     &object_name,
                     &mut RandReader::new(size),
@@ -216,7 +217,7 @@ impl ClientTest {
         let size: usize = 16 + 5 * 1024 * 1024;
         self.client
             .put_object(
-                &mut PutObjectArgs::new(
+                &mut PutObjectArgs::<RandReader, SseCustomerKey>::new(
                     &self.test_bucket,
                     &object_name,
                     &mut RandReader::new(size),
@@ -246,7 +247,7 @@ impl ClientTest {
         let data = "hello, world";
         self.client
             .put_object(
-                &mut PutObjectArgs::new(
+                &mut PutObjectArgs::<BufReader<&[u8]>, SseCustomerKey>::new(
                     &self.test_bucket,
                     &object_name,
                     &mut BufReader::new(data.as_bytes()),
@@ -285,7 +286,12 @@ impl ClientTest {
         file.sync_all().unwrap();
         self.client
             .upload_object(
-                &UploadObjectArgs::new(&self.test_bucket, &object_name, &object_name).unwrap(),
+                &UploadObjectArgs::<SseCustomerKey>::new(
+                    &self.test_bucket,
+                    &object_name,
+                    &object_name,
+                )
+                .unwrap(),
             )
             .await
             .unwrap();
@@ -319,7 +325,12 @@ impl ClientTest {
         file.sync_all().unwrap();
         self.client
             .upload_object(
-                &UploadObjectArgs::new(&self.test_bucket, &object_name, &object_name).unwrap(),
+                &UploadObjectArgs::<SseCustomerKey>::new(
+                    &self.test_bucket,
+                    &object_name,
+                    &object_name,
+                )
+                .unwrap(),
             )
             .await
             .unwrap();
@@ -360,7 +371,7 @@ impl ClientTest {
             let size = 0_usize;
             self.client
                 .put_object(
-                    &mut PutObjectArgs::new(
+                    &mut PutObjectArgs::<RandReader, SseCustomerKey>::new(
                         &self.test_bucket,
                         &object_name,
                         &mut RandReader::new(size),
@@ -407,7 +418,7 @@ impl ClientTest {
             let size = 0_usize;
             self.client
                 .put_object(
-                    &mut PutObjectArgs::new(
+                    &mut PutObjectArgs::<RandReader, SseCustomerKey>::new(
                         &self.test_bucket,
                         &object_name,
                         &mut RandReader::new(size),
@@ -466,7 +477,7 @@ impl ClientTest {
 
         self.client
             .put_object(
-                &mut PutObjectArgs::new(
+                &mut PutObjectArgs::<BufReader<&[u8]>, SseCustomerKey>::new(
                     &self.test_bucket,
                     &object_name,
                     &mut BufReader::new(body.as_bytes()),
@@ -580,7 +591,7 @@ impl ClientTest {
         let size = 16_usize;
         self.client
             .put_object(
-                &mut PutObjectArgs::new(
+                &mut PutObjectArgs::<RandReader, SseCustomerKey>::new(
                     &self.test_bucket,
                     &object_name,
                     &mut RandReader::new(size),
@@ -607,7 +618,7 @@ impl ClientTest {
         let size = 16_usize;
         self.client
             .put_object(
-                &mut PutObjectArgs::new(
+                &mut PutObjectArgs::<RandReader, SseCustomerKey>::new(
                     &self.test_bucket,
                     &src_object_name,
                     &mut RandReader::new(size),
@@ -622,7 +633,7 @@ impl ClientTest {
         let object_name = rand_object_name();
         self.client
             .copy_object(
-                &CopyObjectArgs::new(
+                &CopyObjectArgs::<SseCustomerKey>::new(
                     &self.test_bucket,
                     &object_name,
                     CopySource::new(&self.test_bucket, &src_object_name).unwrap(),
@@ -656,7 +667,7 @@ impl ClientTest {
         let size = 16_usize;
         self.client
             .put_object(
-                &mut PutObjectArgs::new(
+                &mut PutObjectArgs::<RandReader, SseCustomerKey>::new(
                     &self.test_bucket,
                     &src_object_name,
                     &mut RandReader::new(size),
@@ -678,7 +689,12 @@ impl ClientTest {
 
         self.client
             .compose_object(
-                &mut ComposeObjectArgs::new(&self.test_bucket, &object_name, &mut sources).unwrap(),
+                &mut ComposeObjectArgs::<SseCustomerKey>::new(
+                    &self.test_bucket,
+                    &object_name,
+                    &mut sources,
+                )
+                .unwrap(),
             )
             .await
             .unwrap();
@@ -945,7 +961,7 @@ impl ClientTest {
         let size = 16_usize;
         self.client
             .put_object(
-                &mut PutObjectArgs::new(
+                &mut PutObjectArgs::<RandReader, SseCustomerKey>::new(
                     &self.test_bucket,
                     &object_name,
                     &mut RandReader::new(size),
@@ -1055,7 +1071,7 @@ impl ClientTest {
         let obj_resp = self
             .client
             .put_object(
-                &mut PutObjectArgs::new(
+                &mut PutObjectArgs::<RandReader, SseCustomerKey>::new(
                     &bucket_name,
                     &object_name,
                     &mut RandReader::new(size),


### PR DESCRIPTION
Dynamic dispatch is normally a good option to speed up development on high-level code, specially projects focusing more on an outside client consuming it without any interaction with rust internals. On the other hand, using it in a library that should have the least overhead as possible is not ideal. Additionally,  some of the fields that implemented dynamic dispatch where actually hurting implementations in any multi-threaded framework such as `tokio` (`axum`, etc.) as the dynamic fields didn't implemented send so they can be used safely between threads.

In this pull request, we just rewrote many of the dynamic dispatched fields to generic arguments to avoid any weird overhead and improve integrations with other frameworks.

## Important thing to notice
By changing it to generics, we noticed that the instantiation of many of the objects turned a bit ugly as it needed to specify the server side encryption type as it is not passed in the constructor of many of the structs. Maybe consider setting a fixed `Sse` object to avoid this? The changes presented here are fine but maybe it is better to improve the usability by not having to specify that trait.