### PR TITLE
Fix download file error

### DIFF
--- a/src/s3/client.rs
+++ b/src/s3/client.rs
@@ -1471,7 +1471,12 @@ impl Client {
                 unmodified_since: None,
             })
             .await?;
-
+	let path = Path::new(&args.filename);
+        if let Some(parent_dir) = path.parent() {
+            if !parent_dir.exists() {
+                fs::create_dir_all(parent_dir)?;
+            }
+        }
         let mut file = match args.overwrite {
             true => File::create(args.filename)?,
             false => File::options()


### PR DESCRIPTION
Fixed the error where the path does not exist when downloading files with paths like 'xxx/xxx/xxx/xxx.xx'.