### PR TITLE
Add new put and get APIs for objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ md5 = "0.7.0"
 multimap = "0.10.0"
 os_info = "3.7.0"
 percent-encoding = "2.3.0"
-rand = "0.8.5"
 regex = "1.9.4"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
@@ -50,6 +49,7 @@ features = ["native-tls", "blocking", "rustls-tls", "stream"]
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }
+rand = { version = "0.8.5", features = ["small_rng"] }
 
 [[example]]
 name = "file-uploader"

--- a/examples/file-uploader.rs
+++ b/examples/file-uploader.rs
@@ -1,6 +1,6 @@
-use log::{error, info};
-use minio::s3::args::{BucketExistsArgs, MakeBucketArgs, UploadObjectArgs};
-use minio::s3::client::Client;
+use log::info;
+use minio::s3::args::{BucketExistsArgs, MakeBucketArgs};
+use minio::s3::client::ClientBuilder;
 use minio::s3::creds::StaticProvider;
 use minio::s3::http::BaseUrl;
 use std::path::Path;
@@ -9,8 +9,7 @@ use std::path::Path;
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     env_logger::init(); // Note: set environment variable RUST_LOG="INFO" to log info and higher
 
-    //let base_url = "https://play.min.io".parse::<BaseUrl>()?;
-    let base_url: BaseUrl = "http://192.168.178.227:9000".parse::<BaseUrl>()?;
+    let base_url = "https://play.min.io".parse::<BaseUrl>()?;
 
     info!("Trying to connect to MinIO at: `{:?}`", base_url);
 
@@ -20,13 +19,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         None,
     );
 
-    let client = Client::new(
-        base_url.clone(),
-        Some(Box::new(static_provider)),
-        None,
-        None,
-    )
-    .unwrap();
+    let client = ClientBuilder::new(base_url.clone())
+        .provider(Some(Box::new(static_provider)))
+        .build()?;
 
     let bucket_name: &str = "asiatrip";
 
@@ -45,28 +40,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     }
 
     // File we are going to upload to the bucket
-    let filename: &Path = Path::new("/home/user/Photos/asiaphotos.zip");
+    let filename: &Path = Path::new("/tmp/asiaphotos.zip");
 
     // Name of the object that will be stored in the bucket
     let object_name: &str = "asiaphotos-2015.zip";
 
     info!("filename {}", &filename.to_str().unwrap());
 
-    // Check if the file exists
-    let file_exists: bool = filename.exists();
-    if !file_exists {
-        error!("File `{}` does not exist!", filename.display());
-        ()
-    }
-
-    // Upload 'filename' as 'object_name' to bucket 'bucket_name'.
     client
-        .upload_object(
-            &mut UploadObjectArgs::new(&bucket_name, &object_name, &filename.to_str().unwrap())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+        .put_object_from_file(bucket_name, object_name, filename)
+        .send()
+        .await?;
 
     info!(
         "file `{}` is successfully uploaded as object `{object_name}` to bucket `{bucket_name}`.",

--- a/src/s3/args.rs
+++ b/src/s3/args.rs
@@ -105,17 +105,17 @@ fn calc_part_info(
 ) -> Result<(usize, i16), Error> {
     if let Some(v) = part_size {
         if v < MIN_PART_SIZE {
-            return Err(Error::InvalidMinPartSize(v));
+            return Err(Error::InvalidMinPartSize(v as u64));
         }
 
         if v > MAX_PART_SIZE {
-            return Err(Error::InvalidMaxPartSize(v));
+            return Err(Error::InvalidMaxPartSize(v as u64));
         }
     }
 
     if let Some(v) = object_size {
         if v > MAX_OBJECT_SIZE {
-            return Err(Error::InvalidObjectSize(v));
+            return Err(Error::InvalidObjectSize(v as u64));
         }
     } else {
         if part_size.is_none() {
@@ -142,8 +142,8 @@ fn calc_part_info(
 
     if part_count as u16 > MAX_MULTIPART_COUNT {
         return Err(Error::InvalidPartCount(
-            object_size.unwrap(),
-            psize,
+            object_size.unwrap() as u64,
+            psize as u64,
             MAX_MULTIPART_COUNT,
         ));
     }

--- a/src/s3/builders/get_object.rs
+++ b/src/s3/builders/get_object.rs
@@ -1,0 +1,220 @@
+// MinIO Rust Library for Amazon S3 Compatible Cloud Storage
+// Copyright 2023 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use http::Method;
+
+use crate::s3::{
+    client::Client,
+    error::Error,
+    response::GetObjectResponse2,
+    sse::{Sse, SseCustomerKey},
+    types::{S3Api, S3Request, ToS3Request},
+    utils::{check_bucket_name, merge, to_http_header_value, Multimap, UtcTime},
+};
+
+#[derive(Debug, Clone, Default)]
+pub struct GetObject {
+    client: Option<Client>,
+
+    extra_headers: Option<Multimap>,
+    extra_query_params: Option<Multimap>,
+    bucket: String,
+    object: String,
+    version_id: Option<String>,
+    offset: Option<u64>,
+    length: Option<u64>,
+    region: Option<String>,
+    ssec: Option<SseCustomerKey>,
+
+    // Conditionals
+    match_etag: Option<String>,
+    not_match_etag: Option<String>,
+    modified_since: Option<UtcTime>,
+    unmodified_since: Option<UtcTime>,
+}
+
+// builder interface
+impl GetObject {
+    pub fn new(bucket: &str, object: &str) -> Self {
+        Self {
+            bucket: bucket.to_string(),
+            object: object.to_string(),
+            ..Default::default()
+        }
+    }
+
+    pub fn client(mut self, client: &Client) -> Self {
+        self.client = Some(client.clone());
+        self
+    }
+
+    pub fn extra_headers(mut self, extra_headers: Option<Multimap>) -> Self {
+        self.extra_headers = extra_headers;
+        self
+    }
+
+    pub fn extra_query_params(mut self, extra_query_params: Option<Multimap>) -> Self {
+        self.extra_query_params = extra_query_params;
+        self
+    }
+
+    pub fn version_id(mut self, version_id: Option<String>) -> Self {
+        self.version_id = version_id;
+        self
+    }
+
+    pub fn offset(mut self, offset: Option<u64>) -> Self {
+        self.offset = offset;
+        self
+    }
+
+    pub fn length(mut self, length: Option<u64>) -> Self {
+        self.length = length;
+        self
+    }
+
+    pub fn region(mut self, region: Option<String>) -> Self {
+        self.region = region;
+        self
+    }
+
+    pub fn ssec(mut self, ssec: Option<SseCustomerKey>) -> Self {
+        self.ssec = ssec;
+        self
+    }
+
+    pub fn match_etag(mut self, etag: Option<String>) -> Self {
+        self.match_etag = etag;
+        self
+    }
+
+    pub fn not_match_etag(mut self, etag: Option<String>) -> Self {
+        self.not_match_etag = etag;
+        self
+    }
+
+    pub fn modified_since(mut self, time: Option<UtcTime>) -> Self {
+        self.modified_since = time;
+        self
+    }
+
+    pub fn unmodified_since(mut self, time: Option<UtcTime>) -> Self {
+        self.unmodified_since = time;
+        self
+    }
+}
+
+// internal helpers
+impl GetObject {
+    fn get_range_header_value(&self) -> Option<String> {
+        let (offset, length) = match self.length {
+            Some(_) => (Some(self.offset.unwrap_or(0_u64)), self.length),
+            None => (self.offset, None),
+        };
+
+        if let Some(o) = offset {
+            let mut range = String::new();
+            range.push_str("bytes=");
+            range.push_str(&o.to_string());
+            range.push('-');
+            if let Some(l) = length {
+                range.push_str(&(o + l - 1).to_string());
+            }
+            Some(range)
+        } else {
+            None
+        }
+    }
+
+    fn get_headers(&self) -> Multimap {
+        let mut headers = Multimap::new();
+
+        if let Some(val) = self.get_range_header_value() {
+            headers.insert(String::from("Range"), val);
+        }
+
+        if let Some(v) = &self.match_etag {
+            headers.insert(String::from("if-match"), v.to_string());
+        }
+
+        if let Some(v) = &self.not_match_etag {
+            headers.insert(String::from("if-none-match"), v.to_string());
+        }
+
+        if let Some(v) = self.modified_since {
+            headers.insert(String::from("if-modified-since"), to_http_header_value(v));
+        }
+
+        if let Some(v) = self.unmodified_since {
+            headers.insert(String::from("if-unmodified-since"), to_http_header_value(v));
+        }
+
+        if let Some(v) = &self.ssec {
+            merge(&mut headers, &v.headers());
+        }
+
+        headers
+    }
+}
+
+impl ToS3Request for GetObject {
+    fn to_s3request(&self) -> Result<S3Request, Error> {
+        check_bucket_name(&self.bucket, true)?;
+
+        if self.object.is_empty() {
+            return Err(Error::InvalidObjectName(String::from(
+                "object name cannot be empty",
+            )));
+        }
+
+        let client = self.client.clone().ok_or(Error::NoClientProvided)?;
+
+        if let Some(_) = &self.ssec {
+            if !client.is_secure() {
+                return Err(Error::SseTlsRequired(None));
+            }
+        }
+
+        let mut headers = Multimap::new();
+        if let Some(v) = &self.extra_headers {
+            merge(&mut headers, v);
+        }
+        merge(&mut headers, &self.get_headers());
+
+        let mut query_params = Multimap::new();
+        if let Some(v) = &self.extra_query_params {
+            merge(&mut query_params, v);
+        }
+        if let Some(v) = &self.version_id {
+            query_params.insert(String::from("versionId"), v.to_string());
+        }
+
+        let req = S3Request::new(
+            self.client.as_ref().ok_or(Error::NoClientProvided)?,
+            Method::GET,
+        )
+        .region(self.region.as_deref())
+        .bucket(Some(&self.bucket))
+        .object(Some(&self.object))
+        .query_params(query_params)
+        .headers(headers);
+
+        Ok(req)
+    }
+}
+
+impl S3Api for GetObject {
+    type S3Response = GetObjectResponse2;
+}

--- a/src/s3/builders/object_content.rs
+++ b/src/s3/builders/object_content.rs
@@ -1,0 +1,242 @@
+// MinIO Rust Library for Amazon S3 Compatible Cloud Storage
+// Copyright 2023 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::pin::Pin;
+
+use bytes::{Bytes, BytesMut};
+use futures_util::Stream;
+use tokio::io::AsyncRead;
+use tokio_stream::StreamExt;
+
+type IoResult<T> = Result<T, std::io::Error>;
+
+pub struct ObjectContent {
+    r: Pin<Box<dyn Stream<Item = IoResult<Bytes>>>>,
+    extra: Option<Bytes>,
+    size: Option<u64>,
+}
+
+impl From<Bytes> for ObjectContent {
+    fn from(value: Bytes) -> Self {
+        let n = value.len();
+        ObjectContent {
+            r: Box::pin(tokio_stream::iter(vec![Ok(value)])),
+            extra: None,
+            size: Some(n as u64),
+        }
+    }
+}
+
+impl From<String> for ObjectContent {
+    fn from(value: String) -> Self {
+        let n = value.len();
+        ObjectContent {
+            r: Box::pin(tokio_stream::iter(vec![Ok(Bytes::from(value))])),
+            extra: None,
+            size: Some(n as u64),
+        }
+    }
+}
+
+impl From<Vec<u8>> for ObjectContent {
+    fn from(value: Vec<u8>) -> Self {
+        let n = value.len();
+        ObjectContent {
+            r: Box::pin(tokio_stream::iter(vec![Ok(Bytes::from(value))])),
+            extra: None,
+            size: Some(n as u64),
+        }
+    }
+}
+
+impl ObjectContent {
+    pub fn new(r: impl Stream<Item = IoResult<Bytes>> + 'static, size: Option<u64>) -> Self {
+        let r = Box::pin(r);
+        Self {
+            r,
+            extra: None,
+            size,
+        }
+    }
+
+    pub fn empty() -> Self {
+        Self {
+            r: Box::pin(tokio_stream::iter(vec![])),
+            extra: None,
+            size: Some(0),
+        }
+    }
+
+    pub fn from_reader(r: impl AsyncRead + Send + Sync + 'static, size: Option<u64>) -> Self {
+        let pinned = Box::pin(r);
+        let r = tokio_util::io::ReaderStream::new(pinned);
+        Self {
+            r: Box::pin(r),
+            extra: None,
+            size,
+        }
+    }
+
+    pub fn get_size(&self) -> Option<u64> {
+        self.size
+    }
+
+    pub fn stream(self) -> impl Stream<Item = IoResult<Bytes>> {
+        self.r
+    }
+
+    // Read as many bytes as possible up to `n` and return a `SegmentedBytes`
+    // object.
+    pub async fn read_upto(&mut self, n: usize) -> IoResult<SegmentedBytes> {
+        let mut segmented_bytes = SegmentedBytes::new();
+        let mut remaining = n;
+        if let Some(extra) = self.extra.take() {
+            let len = extra.len();
+            if len <= remaining {
+                segmented_bytes.append(extra);
+                remaining -= len;
+            } else {
+                segmented_bytes.append(extra.slice(0..remaining));
+                self.extra = Some(extra.slice(remaining..));
+                return Ok(segmented_bytes);
+            }
+        }
+        while remaining > 0 {
+            let bytes = self.r.next().await;
+            if bytes.is_none() {
+                break;
+            }
+            let bytes = bytes.unwrap()?;
+            let len = bytes.len();
+            if len == 0 {
+                break;
+            }
+            if len <= remaining {
+                segmented_bytes.append(bytes);
+                remaining -= len;
+            } else {
+                segmented_bytes.append(bytes.slice(0..remaining));
+                self.extra = Some(bytes.slice(remaining..));
+                break;
+            }
+        }
+        Ok(segmented_bytes)
+    }
+
+    pub async fn to_segmented_bytes(mut self) -> IoResult<SegmentedBytes> {
+        let mut segmented_bytes = SegmentedBytes::new();
+        while let Some(bytes) = self.r.next().await {
+            let bytes = bytes?;
+            if bytes.is_empty() {
+                break;
+            }
+            segmented_bytes.append(bytes);
+        }
+        Ok(segmented_bytes)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SegmentedBytes {
+    segments: Vec<Vec<Bytes>>,
+    total_size: usize,
+}
+
+impl Default for SegmentedBytes {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SegmentedBytes {
+    pub fn new() -> Self {
+        SegmentedBytes {
+            segments: Vec::new(),
+            total_size: 0,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.total_size
+    }
+
+    pub fn append(&mut self, bytes: Bytes) {
+        let last_segment = self.segments.last_mut();
+        if let Some(last_segment) = last_segment {
+            let last_len = last_segment.last().map(|b| b.len());
+            if let Some(last_len) = last_len {
+                if bytes.len() == last_len {
+                    self.total_size += bytes.len();
+                    last_segment.push(bytes);
+                    return;
+                }
+            }
+        }
+        self.total_size += bytes.len();
+        self.segments.push(vec![bytes]);
+    }
+
+    pub fn iter(&self) -> SegmentedBytesIterator {
+        SegmentedBytesIterator {
+            sb: self,
+            current_segment: 0,
+            current_segment_index: 0,
+        }
+    }
+
+    // Copy all the content into a single `Bytes` object.
+    pub fn to_bytes(&self) -> Bytes {
+        let mut buf = BytesMut::with_capacity(self.total_size);
+        for segment in &self.segments {
+            for bytes in segment {
+                buf.extend_from_slice(&bytes);
+            }
+        }
+        buf.freeze()
+    }
+}
+
+impl From<Bytes> for SegmentedBytes {
+    fn from(bytes: Bytes) -> Self {
+        let mut sb = SegmentedBytes::new();
+        sb.append(bytes);
+        sb
+    }
+}
+
+pub struct SegmentedBytesIterator<'a> {
+    sb: &'a SegmentedBytes,
+    current_segment: usize,
+    current_segment_index: usize,
+}
+
+impl Iterator for SegmentedBytesIterator<'_> {
+    type Item = Bytes;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current_segment >= self.sb.segments.len() {
+            return None;
+        }
+        let segment = &self.sb.segments[self.current_segment];
+        if self.current_segment_index >= segment.len() {
+            self.current_segment += 1;
+            self.current_segment_index = 0;
+            return self.next();
+        }
+        let bytes = &segment[self.current_segment_index];
+        self.current_segment_index += 1;
+        Some(bytes.clone())
+    }
+}

--- a/src/s3/builders/put_object.rs
+++ b/src/s3/builders/put_object.rs
@@ -1,0 +1,1012 @@
+// MinIO Rust Library for Amazon S3 Compatible Cloud Storage
+// Copyright 2023 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use bytes::BytesMut;
+use http::Method;
+
+use crate::s3::{
+    builders::ObjectContent,
+    client::Client,
+    error::Error,
+    response::{
+        AbortMultipartUploadResponse2, CompleteMultipartUploadResponse2,
+        CreateMultipartUploadResponse2, PutObjectResponse2, UploadPartResponse2,
+    },
+    sse::Sse,
+    types::{Part, Retention, S3Api, S3Request, ToS3Request},
+    utils::{check_bucket_name, md5sum_hash, merge, to_iso8601utc, urlencode, Multimap},
+};
+
+use super::SegmentedBytes;
+
+/// Argument for
+/// [create_multipart_upload()](crate::s3::client::Client::create_multipart_upload)
+/// API
+#[derive(Clone, Debug, Default)]
+pub struct CreateMultipartUpload {
+    client: Option<Client>,
+
+    extra_headers: Option<Multimap>,
+    extra_query_params: Option<Multimap>,
+    region: Option<String>,
+    bucket: String,
+    object: String,
+}
+
+impl CreateMultipartUpload {
+    pub fn new(bucket: &str, object: &str) -> Self {
+        CreateMultipartUpload {
+            bucket: bucket.to_string(),
+            object: object.to_string(),
+            ..Default::default()
+        }
+    }
+
+    pub fn client(mut self, client: &Client) -> Self {
+        self.client = Some(client.clone());
+        self
+    }
+
+    pub fn extra_headers(mut self, extra_headers: Option<Multimap>) -> Self {
+        self.extra_headers = extra_headers;
+        self
+    }
+
+    pub fn extra_query_params(mut self, extra_query_params: Option<Multimap>) -> Self {
+        self.extra_query_params = extra_query_params;
+        self
+    }
+
+    pub fn region(mut self, region: Option<String>) -> Self {
+        self.region = region;
+        self
+    }
+}
+
+impl ToS3Request for CreateMultipartUpload {
+    fn to_s3request(&self) -> Result<S3Request, Error> {
+        check_bucket_name(&self.bucket, true)?;
+
+        let mut headers = Multimap::new();
+        if let Some(v) = &self.extra_headers {
+            merge(&mut headers, v);
+        }
+        if !headers.contains_key("Content-Type") {
+            headers.insert(
+                String::from("Content-Type"),
+                String::from("application/octet-stream"),
+            );
+        }
+
+        let mut query_params = Multimap::new();
+        if let Some(v) = &self.extra_query_params {
+            merge(&mut query_params, v);
+        }
+        query_params.insert(String::from("uploads"), String::new());
+
+        let req = S3Request::new(
+            self.client.as_ref().ok_or(Error::NoClientProvided)?,
+            Method::POST,
+        )
+        .region(self.region.as_deref())
+        .bucket(Some(&self.bucket))
+        .object(Some(&self.object))
+        .query_params(query_params)
+        .headers(headers);
+
+        Ok(req)
+    }
+}
+
+impl S3Api for CreateMultipartUpload {
+    type S3Response = CreateMultipartUploadResponse2;
+}
+
+/// Argument for
+/// [abort_multipart_upload()](crate::s3::client::Client::abort_multipart_upload)
+/// API
+#[derive(Clone, Debug, Default)]
+pub struct AbortMultipartUpload {
+    client: Option<Client>,
+
+    extra_headers: Option<Multimap>,
+    extra_query_params: Option<Multimap>,
+    region: Option<String>,
+    bucket: String,
+    object: String,
+    upload_id: String,
+}
+
+impl AbortMultipartUpload {
+    pub fn new(bucket: &str, object: &str, upload_id: &str) -> Self {
+        AbortMultipartUpload {
+            bucket: bucket.to_string(),
+            object: object.to_string(),
+            upload_id: upload_id.to_string(),
+            ..Default::default()
+        }
+    }
+
+    pub fn client(mut self, client: &Client) -> Self {
+        self.client = Some(client.clone());
+        self
+    }
+
+    pub fn extra_headers(mut self, extra_headers: Option<Multimap>) -> Self {
+        self.extra_headers = extra_headers;
+        self
+    }
+
+    pub fn extra_query_params(mut self, extra_query_params: Option<Multimap>) -> Self {
+        self.extra_query_params = extra_query_params;
+        self
+    }
+
+    pub fn region(mut self, region: Option<String>) -> Self {
+        self.region = region;
+        self
+    }
+}
+
+impl ToS3Request for AbortMultipartUpload {
+    fn to_s3request(&self) -> Result<S3Request, Error> {
+        check_bucket_name(&self.bucket, true)?;
+
+        let mut headers = Multimap::new();
+        if let Some(v) = &self.extra_headers {
+            merge(&mut headers, v);
+        }
+
+        let mut query_params = Multimap::new();
+        if let Some(v) = &self.extra_query_params {
+            merge(&mut query_params, v);
+        }
+        query_params.insert(
+            String::from("uploadId"),
+            urlencode(&self.upload_id).to_string(),
+        );
+
+        let req = S3Request::new(
+            self.client.as_ref().ok_or(Error::NoClientProvided)?,
+            Method::DELETE,
+        )
+        .region(self.region.as_deref())
+        .bucket(Some(&self.bucket))
+        .object(Some(&self.object))
+        .query_params(query_params)
+        .headers(headers);
+
+        Ok(req)
+    }
+}
+
+impl S3Api for AbortMultipartUpload {
+    type S3Response = AbortMultipartUploadResponse2;
+}
+
+/// Argument for
+/// [complete_multipart_upload()](crate::s3::client::Client::complete_multipart_upload)
+/// API
+#[derive(Clone, Debug, Default)]
+pub struct CompleteMultipartUpload {
+    client: Option<Client>,
+
+    extra_headers: Option<Multimap>,
+    extra_query_params: Option<Multimap>,
+    region: Option<String>,
+    bucket: String,
+    object: String,
+    upload_id: String,
+    parts: Vec<Part>,
+}
+
+impl CompleteMultipartUpload {
+    pub fn new(bucket: &str, object: &str, upload_id: &str, parts: Vec<Part>) -> Self {
+        CompleteMultipartUpload {
+            bucket: bucket.to_string(),
+            object: object.to_string(),
+            upload_id: upload_id.to_string(),
+            parts,
+            ..Default::default()
+        }
+    }
+
+    pub fn client(mut self, client: &Client) -> Self {
+        self.client = Some(client.clone());
+        self
+    }
+
+    pub fn extra_headers(mut self, extra_headers: Option<Multimap>) -> Self {
+        self.extra_headers = extra_headers;
+        self
+    }
+
+    pub fn extra_query_params(mut self, extra_query_params: Option<Multimap>) -> Self {
+        self.extra_query_params = extra_query_params;
+        self
+    }
+
+    pub fn region(mut self, region: Option<String>) -> Self {
+        self.region = region;
+        self
+    }
+}
+
+impl ToS3Request for CompleteMultipartUpload {
+    fn to_s3request(&self) -> Result<S3Request, Error> {
+        check_bucket_name(&self.bucket, true)?;
+
+        if self.object.is_empty() {
+            return Err(Error::InvalidObjectName(String::from(
+                "object name cannot be empty",
+            )));
+        }
+
+        if self.upload_id.is_empty() {
+            return Err(Error::InvalidUploadId(String::from(
+                "upload ID cannot be empty",
+            )));
+        }
+
+        if self.parts.is_empty() {
+            return Err(Error::EmptyParts(String::from("parts cannot be empty")));
+        }
+
+        // Set capacity of the byte-buffer based on the part count - attempting
+        // to avoid extra allocations when building the XML payload.
+        let mut data = BytesMut::with_capacity(100 * self.parts.len() + 100);
+        data.extend_from_slice(b"<CompleteMultipartUpload>");
+        for part in self.parts.iter() {
+            data.extend_from_slice(b"<Part><PartNumber>");
+            data.extend_from_slice(part.number.to_string().as_bytes());
+            data.extend_from_slice(b"</PartNumber><ETag>");
+            data.extend_from_slice(part.etag.as_bytes());
+            data.extend_from_slice(b"</ETag></Part>");
+        }
+        data.extend_from_slice(b"</CompleteMultipartUpload>");
+        let data = data.freeze();
+
+        let mut headers = Multimap::new();
+        if let Some(v) = &self.extra_headers {
+            merge(&mut headers, v);
+        }
+        headers.insert(
+            String::from("Content-Type"),
+            String::from("application/xml"),
+        );
+        headers.insert(String::from("Content-MD5"), md5sum_hash(data.as_ref()));
+
+        let mut query_params = Multimap::new();
+        if let Some(v) = &self.extra_query_params {
+            merge(&mut query_params, v);
+        }
+        query_params.insert(String::from("uploadId"), self.upload_id.to_string());
+
+        let req = S3Request::new(
+            self.client.as_ref().ok_or(Error::NoClientProvided)?,
+            Method::POST,
+        )
+        .region(self.region.as_deref())
+        .bucket(Some(&self.bucket))
+        .object(Some(&self.object))
+        .query_params(query_params)
+        .headers(headers)
+        .body(Some(data.into()));
+
+        Ok(req)
+    }
+}
+
+impl S3Api for CompleteMultipartUpload {
+    type S3Response = CompleteMultipartUploadResponse2;
+}
+
+/// Argument for [upload_part()](crate::s3::client::Client::upload_part) S3 API
+#[derive(Debug, Clone, Default)]
+pub struct UploadPart {
+    client: Option<Client>,
+
+    extra_headers: Option<Multimap>,
+    extra_query_params: Option<Multimap>,
+    bucket: String,
+    object: String,
+    region: Option<String>,
+    user_metadata: Option<Multimap>,
+    sse: Option<Arc<dyn Sse>>,
+    tags: Option<HashMap<String, String>>,
+    retention: Option<Retention>,
+    legal_hold: bool,
+    data: SegmentedBytes,
+
+    // These are optional as the struct is reused for PutObject.
+    upload_id: Option<String>,
+    part_number: Option<u16>,
+}
+
+impl UploadPart {
+    pub fn new(
+        bucket: &str,
+        object: &str,
+        upload_id: &str,
+        part_number: u16,
+        data: SegmentedBytes,
+    ) -> Self {
+        UploadPart {
+            bucket: bucket.to_string(),
+            object: object.to_string(),
+            upload_id: Some(upload_id.to_string()),
+            part_number: Some(part_number),
+            data,
+            ..Default::default()
+        }
+    }
+
+    pub fn client(mut self, client: &Client) -> Self {
+        self.client = Some(client.clone());
+        self
+    }
+
+    pub fn extra_headers(mut self, extra_headers: Option<Multimap>) -> Self {
+        self.extra_headers = extra_headers;
+        self
+    }
+
+    pub fn extra_query_params(mut self, extra_query_params: Option<Multimap>) -> Self {
+        self.extra_query_params = extra_query_params;
+        self
+    }
+
+    pub fn region(mut self, region: Option<String>) -> Self {
+        self.region = region;
+        self
+    }
+
+    pub fn user_metadata(mut self, user_metadata: Option<Multimap>) -> Self {
+        self.user_metadata = user_metadata;
+        self
+    }
+
+    pub fn sse(mut self, sse: Option<Arc<dyn Sse>>) -> Self {
+        self.sse = sse;
+        self
+    }
+
+    pub fn tags(mut self, tags: Option<HashMap<String, String>>) -> Self {
+        self.tags = tags;
+        self
+    }
+
+    pub fn retention(mut self, retention: Option<Retention>) -> Self {
+        self.retention = retention;
+        self
+    }
+
+    pub fn legal_hold(mut self, legal_hold: bool) -> Self {
+        self.legal_hold = legal_hold;
+        self
+    }
+
+    fn get_headers(&self) -> Multimap {
+        object_write_args_headers(
+            self.extra_headers.as_ref(),
+            None,
+            self.user_metadata.as_ref(),
+            &self.sse,
+            self.tags.as_ref(),
+            self.retention.as_ref(),
+            self.legal_hold,
+        )
+    }
+
+    fn validate(&self) -> Result<(), Error> {
+        check_bucket_name(&self.bucket, true)?;
+
+        if self.object.is_empty() {
+            return Err(Error::InvalidObjectName(String::from(
+                "object name cannot be empty",
+            )));
+        }
+
+        if let Some(upload_id) = &self.upload_id {
+            if upload_id.is_empty() {
+                return Err(Error::InvalidUploadId(String::from(
+                    "upload ID cannot be empty",
+                )));
+            }
+        }
+
+        if let Some(part_number) = self.part_number {
+            if !(1..=10000).contains(&part_number) {
+                return Err(Error::InvalidPartNumber(String::from(
+                    "part number must be between 1 and 1000",
+                )));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl ToS3Request for UploadPart {
+    fn to_s3request(&self) -> Result<S3Request, Error> {
+        self.validate()?;
+
+        let headers = self.get_headers();
+
+        let mut query_params = Multimap::new();
+        if let Some(v) = &self.extra_query_params {
+            merge(&mut query_params, v);
+        }
+        if let Some(upload_id) = &self.upload_id {
+            query_params.insert(String::from("uploadId"), upload_id.to_string());
+        }
+        if let Some(part_number) = self.part_number {
+            query_params.insert(String::from("partNumber"), part_number.to_string());
+        }
+
+        let req = S3Request::new(
+            self.client.as_ref().ok_or(Error::NoClientProvided)?,
+            Method::PUT,
+        )
+        .region(self.region.as_deref())
+        .bucket(Some(&self.bucket))
+        .object(Some(&self.object))
+        .query_params(query_params)
+        .headers(headers)
+        .body(Some(self.data.clone().into()));
+
+        Ok(req)
+    }
+}
+
+impl S3Api for UploadPart {
+    type S3Response = UploadPartResponse2;
+}
+
+/// Argument builder for PutObject S3 API. This is a lower-level API.
+#[derive(Debug, Clone, Default)]
+pub struct PutObject(UploadPart);
+
+impl PutObject {
+    pub fn new(bucket: &str, object: &str, data: SegmentedBytes) -> Self {
+        PutObject(UploadPart {
+            bucket: bucket.to_string(),
+            object: object.to_string(),
+            data,
+            ..Default::default()
+        })
+    }
+
+    pub fn client(mut self, client: &Client) -> Self {
+        self.0.client = Some(client.clone());
+        self
+    }
+
+    pub fn extra_headers(mut self, extra_headers: Option<Multimap>) -> Self {
+        self.0.extra_headers = extra_headers;
+        self
+    }
+
+    pub fn extra_query_params(mut self, extra_query_params: Option<Multimap>) -> Self {
+        self.0.extra_query_params = extra_query_params;
+        self
+    }
+
+    pub fn region(mut self, region: Option<String>) -> Self {
+        self.0.region = region;
+        self
+    }
+
+    pub fn user_metadata(mut self, user_metadata: Option<Multimap>) -> Self {
+        self.0.user_metadata = user_metadata;
+        self
+    }
+
+    pub fn sse(mut self, sse: Option<Arc<dyn Sse>>) -> Self {
+        self.0.sse = sse;
+        self
+    }
+
+    pub fn tags(mut self, tags: Option<HashMap<String, String>>) -> Self {
+        self.0.tags = tags;
+        self
+    }
+
+    pub fn retention(mut self, retention: Option<Retention>) -> Self {
+        self.0.retention = retention;
+        self
+    }
+
+    pub fn legal_hold(mut self, legal_hold: bool) -> Self {
+        self.0.legal_hold = legal_hold;
+        self
+    }
+}
+
+impl ToS3Request for PutObject {
+    fn to_s3request(&self) -> Result<S3Request, Error> {
+        self.0.to_s3request()
+    }
+}
+
+impl S3Api for PutObject {
+    type S3Response = PutObjectResponse2;
+}
+
+fn object_write_args_headers(
+    extra_headers: Option<&Multimap>,
+    headers: Option<&Multimap>,
+    user_metadata: Option<&Multimap>,
+    sse: &Option<Arc<dyn Sse>>,
+    tags: Option<&HashMap<String, String>>,
+    retention: Option<&Retention>,
+    legal_hold: bool,
+) -> Multimap {
+    let mut map = Multimap::new();
+
+    if let Some(v) = extra_headers {
+        merge(&mut map, v);
+    }
+
+    if let Some(v) = headers {
+        merge(&mut map, v);
+    }
+
+    if let Some(v) = user_metadata {
+        merge(&mut map, v);
+    }
+
+    if let Some(v) = sse {
+        merge(&mut map, &v.headers());
+    }
+
+    if let Some(v) = tags {
+        let mut tagging = String::new();
+        for (key, value) in v.iter() {
+            if !tagging.is_empty() {
+                tagging.push('&');
+            }
+            tagging.push_str(&urlencode(key));
+            tagging.push('=');
+            tagging.push_str(&urlencode(value));
+        }
+
+        if !tagging.is_empty() {
+            map.insert(String::from("x-amz-tagging"), tagging);
+        }
+    }
+
+    if let Some(v) = retention {
+        map.insert(String::from("x-amz-object-lock-mode"), v.mode.to_string());
+        map.insert(
+            String::from("x-amz-object-lock-retain-until-date"),
+            to_iso8601utc(v.retain_until_date),
+        );
+    }
+
+    if legal_hold {
+        map.insert(
+            String::from("x-amz-object-lock-legal-hold"),
+            String::from("ON"),
+        );
+    }
+
+    map
+}
+
+// PutObjectContent takes a `ObjectContent` stream and uploads it to MinIO/S3.
+//
+// It is a higher level API and handles multipart uploads transparently.
+pub struct PutObjectContent {
+    client: Option<Client>,
+
+    extra_headers: Option<Multimap>,
+    extra_query_params: Option<Multimap>,
+    region: Option<String>,
+    bucket: String,
+    object: String,
+    user_metadata: Option<Multimap>,
+    sse: Option<Arc<dyn Sse>>,
+    tags: Option<HashMap<String, String>>,
+    retention: Option<Retention>,
+    legal_hold: bool,
+    part_size: Option<u64>,
+    content_type: String,
+
+    // source data
+    input_reader: Option<ObjectContent>,
+    file_path: Option<PathBuf>,
+
+    // Computed.
+    // expected_parts: Option<u16>,
+    reader: ObjectContent,
+    part_count: u16,
+}
+
+impl PutObjectContent {
+    pub fn new(bucket: &str, object: &str, content: impl Into<ObjectContent>) -> Self {
+        PutObjectContent {
+            bucket: bucket.to_string(),
+            object: object.to_string(),
+            input_reader: Some(content.into()),
+            file_path: None,
+            client: None,
+            extra_headers: None,
+            extra_query_params: None,
+            region: None,
+            user_metadata: None,
+            sse: None,
+            tags: None,
+            retention: None,
+            legal_hold: false,
+            part_size: None,
+            content_type: String::from("application/octet-stream"),
+            reader: ObjectContent::empty(),
+            part_count: 0,
+        }
+    }
+
+    pub fn from_file(bucket: &str, object: &str, file_path: &Path) -> Self {
+        PutObjectContent {
+            bucket: bucket.to_string(),
+            object: object.to_string(),
+            input_reader: None,
+            file_path: Some(file_path.to_path_buf()),
+            client: None,
+            extra_headers: None,
+            extra_query_params: None,
+            region: None,
+            user_metadata: None,
+            sse: None,
+            tags: None,
+            retention: None,
+            legal_hold: false,
+            part_size: None,
+            content_type: String::from("application/octet-stream"),
+            reader: ObjectContent::empty(),
+            part_count: 0,
+        }
+    }
+
+    pub fn client(mut self, client: &Client) -> Self {
+        self.client = Some(client.clone());
+        self
+    }
+
+    pub fn extra_headers(mut self, extra_headers: Option<Multimap>) -> Self {
+        self.extra_headers = extra_headers;
+        self
+    }
+
+    pub fn extra_query_params(mut self, extra_query_params: Option<Multimap>) -> Self {
+        self.extra_query_params = extra_query_params;
+        self
+    }
+
+    pub fn region(mut self, region: Option<String>) -> Self {
+        self.region = region;
+        self
+    }
+
+    pub fn user_metadata(mut self, user_metadata: Option<Multimap>) -> Self {
+        self.user_metadata = user_metadata;
+        self
+    }
+
+    pub fn sse(mut self, sse: Option<Arc<dyn Sse>>) -> Self {
+        self.sse = sse;
+        self
+    }
+
+    pub fn tags(mut self, tags: Option<HashMap<String, String>>) -> Self {
+        self.tags = tags;
+        self
+    }
+
+    pub fn retention(mut self, retention: Option<Retention>) -> Self {
+        self.retention = retention;
+        self
+    }
+
+    pub fn legal_hold(mut self, legal_hold: bool) -> Self {
+        self.legal_hold = legal_hold;
+        self
+    }
+
+    pub fn part_size(mut self, part_size: Option<u64>) -> Self {
+        self.part_size = part_size;
+        self
+    }
+
+    pub fn content_type(mut self, content_type: String) -> Self {
+        self.content_type = content_type;
+        self
+    }
+
+    pub async fn send(mut self) -> Result<PutObjectResponse2, Error> {
+        check_bucket_name(&self.bucket, true)?;
+
+        if self.object.is_empty() {
+            return Err(Error::InvalidObjectName(String::from(
+                "object name cannot be empty",
+            )));
+        }
+
+        if self.input_reader.is_none() {
+            // This unwrap is safe as the public API ensures that the file_path
+            // or the reader is always set.
+            let file_path = self.file_path.as_ref().unwrap();
+            let file = tokio::fs::File::open(file_path).await?;
+            let size = file.metadata().await?.len();
+            self.reader = ObjectContent::from_reader(file, Some(size));
+        } else {
+            self.reader = self.input_reader.take().unwrap();
+        }
+
+        let object_size = self.reader.get_size();
+        let (psize, expected_parts) = calc_part_info(object_size, self.part_size)?;
+        assert_ne!(expected_parts, Some(0));
+        self.part_size = Some(psize);
+
+        let client = self.client.clone().ok_or(Error::NoClientProvided)?;
+
+        if let Some(v) = &self.sse {
+            if v.tls_required() && !client.is_secure() {
+                return Err(Error::SseTlsRequired(None));
+            }
+        }
+
+        // Read the first part.
+        let seg_bytes = self.reader.read_upto(psize as usize).await?;
+
+        // In the first part read, if:
+        //
+        //   - we got less than the expected part size, OR
+        //   - we are expecting only one part to be uploaded,
+        //
+        // we upload it as a simple put object.
+        if (seg_bytes.len() as u64) < psize || expected_parts == Some(1) {
+            let po = self.to_put_object(seg_bytes);
+            return po.send().await;
+        }
+
+        // Otherwise, we start a multipart upload.
+        let create_mpu = CreateMultipartUpload::new(&self.bucket, &self.object)
+            .client(&client)
+            .extra_headers(self.extra_headers.clone())
+            .extra_query_params(self.extra_query_params.clone())
+            .region(self.region.clone());
+
+        let create_mpu_resp = create_mpu.send().await?;
+        let upload_id = create_mpu_resp.upload_id;
+
+        // This ensures that if we fail to complete the upload due to an error,
+        // we abort the upload.
+        let mut droppable_upload_id = DroppableUploadId {
+            client: client.clone(),
+            bucket: self.bucket.clone(),
+            object: self.object.clone(),
+            upload_id: Some(upload_id.clone()),
+        };
+
+        let mut done = false;
+        let mut part_number = 0;
+        let mut parts: Vec<Part> = if let Some(pc) = expected_parts {
+            Vec::with_capacity(pc as usize)
+        } else {
+            Vec::new()
+        };
+
+        let mut first_part = Some(seg_bytes);
+        while !done {
+            let part_content = {
+                if let Some(v) = first_part.take() {
+                    v
+                } else {
+                    self.reader.read_upto(psize as usize).await?
+                }
+            };
+            part_number += 1;
+            let buffer_size = part_content.len() as u64;
+
+            assert!(buffer_size <= psize, "{:?} <= {:?}", buffer_size, psize);
+
+            if buffer_size == 0 && part_number > 1 {
+                // We are done as we uploaded at least 1 part and we have
+                // reached the end of the stream.
+                break;
+            }
+
+            // Check if we have too many parts to upload.
+            if expected_parts.is_none() && part_number > MAX_MULTIPART_COUNT {
+                return Err(Error::InvalidPartCount(
+                    object_size.unwrap_or(0),
+                    self.part_size.unwrap(),
+                    self.part_count,
+                ));
+            }
+
+            // Upload the part now.
+            let upload_part = self.to_upload_part(part_content, &upload_id, part_number);
+            let upload_part_resp = upload_part.send().await?;
+            parts.push(Part {
+                number: part_number,
+                etag: upload_part_resp.etag,
+            });
+
+            // Finally check if we are done.
+            if buffer_size < psize {
+                done = true;
+            }
+        }
+
+        // Complete the multipart upload.
+        let complete_mpu = self.to_complete_multipart_upload(&upload_id, parts);
+        complete_mpu.send().await.map(|v| {
+            // We are done with the upload. Clear the upload ID to prevent a
+            // useless abort multipart upload call.
+            droppable_upload_id.upload_id = None;
+            v
+        })
+    }
+}
+
+impl PutObjectContent {
+    fn to_put_object(&self, data: SegmentedBytes) -> PutObject {
+        PutObject(UploadPart {
+            client: self.client.clone(),
+            extra_headers: self.extra_headers.clone(),
+            extra_query_params: self.extra_query_params.clone(),
+            bucket: self.bucket.clone(),
+            object: self.object.clone(),
+            region: self.region.clone(),
+            user_metadata: self.user_metadata.clone(),
+            sse: self.sse.clone(),
+            tags: self.tags.clone(),
+            retention: self.retention.clone(),
+            legal_hold: self.legal_hold,
+            part_number: None,
+            upload_id: None,
+            data,
+        })
+    }
+
+    fn to_upload_part(
+        &self,
+        data: SegmentedBytes,
+        upload_id: &str,
+        part_number: u16,
+    ) -> UploadPart {
+        UploadPart {
+            client: self.client.clone(),
+            extra_headers: self.extra_headers.clone(),
+            extra_query_params: self.extra_query_params.clone(),
+            bucket: self.bucket.clone(),
+            object: self.object.clone(),
+            region: self.region.clone(),
+            user_metadata: self.user_metadata.clone(),
+            sse: self.sse.clone(),
+            tags: self.tags.clone(),
+            retention: self.retention.clone(),
+            legal_hold: self.legal_hold,
+            part_number: Some(part_number),
+            upload_id: Some(upload_id.to_string()),
+            data,
+        }
+    }
+
+    fn to_complete_multipart_upload(
+        &self,
+        upload_id: &str,
+        parts: Vec<Part>,
+    ) -> CompleteMultipartUpload {
+        CompleteMultipartUpload {
+            client: self.client.clone(),
+            extra_headers: self.extra_headers.clone(),
+            extra_query_params: self.extra_query_params.clone(),
+            bucket: self.bucket.clone(),
+            object: self.object.clone(),
+            region: self.region.clone(),
+            parts,
+            upload_id: upload_id.to_string(),
+        }
+    }
+}
+
+struct DroppableUploadId {
+    client: Client,
+    bucket: String,
+    object: String,
+    upload_id: Option<String>,
+}
+
+impl Drop for DroppableUploadId {
+    fn drop(&mut self) {
+        if let Some(upload_id) = &self.upload_id {
+            let _ = AbortMultipartUpload::new(&self.bucket, &self.object, &upload_id)
+                .client(&self.client)
+                .send();
+        }
+    }
+}
+
+pub const MIN_PART_SIZE: u64 = 5 * 1024 * 1024; // 5 MiB
+pub const MAX_PART_SIZE: u64 = 1024 * MIN_PART_SIZE; // 5 GiB
+pub const MAX_OBJECT_SIZE: u64 = 1024 * MAX_PART_SIZE; // 5 TiB
+pub const MAX_MULTIPART_COUNT: u16 = 10_000;
+
+// Returns the size of each part to upload and the total number of parts. The
+// number of parts is `None` when the object size is unknown.
+fn calc_part_info(
+    object_size: Option<u64>,
+    part_size: Option<u64>,
+) -> Result<(u64, Option<u16>), Error> {
+    // Validate arguments against limits.
+    if let Some(v) = part_size {
+        if v < MIN_PART_SIZE {
+            return Err(Error::InvalidMinPartSize(v));
+        }
+
+        if v > MAX_PART_SIZE {
+            return Err(Error::InvalidMaxPartSize(v));
+        }
+    }
+
+    if let Some(v) = object_size {
+        if v > MAX_OBJECT_SIZE {
+            return Err(Error::InvalidObjectSize(v));
+        }
+    }
+
+    match (object_size, part_size) {
+        (None, None) => return Err(Error::MissingPartSize),
+        (None, Some(part_size)) => return Ok((part_size, None)),
+        (Some(object_size), None) => {
+            let mut psize: u64 = (object_size as f64 / MAX_MULTIPART_COUNT as f64).ceil() as u64;
+
+            psize = MIN_PART_SIZE * (psize as f64 / MIN_PART_SIZE as f64).ceil() as u64;
+
+            if psize > object_size {
+                psize = object_size;
+            }
+
+            let part_count = if psize > 0 {
+                (object_size as f64 / psize as f64).ceil() as u16
+            } else {
+                1
+            };
+
+            return Ok((psize, Some(part_count)));
+        }
+        (Some(object_size), Some(part_size)) => {
+            let part_count = (object_size as f64 / part_size as f64).ceil() as u16;
+            if part_count == 0 || part_count > MAX_MULTIPART_COUNT {
+                return Err(Error::InvalidPartCount(
+                    object_size,
+                    part_size,
+                    MAX_MULTIPART_COUNT,
+                ));
+            }
+
+            return Ok((part_size, Some(part_count)));
+        }
+    }
+}

--- a/src/s3/client/get_object.rs
+++ b/src/s3/client/get_object.rs
@@ -1,3 +1,6 @@
+// MinIO Rust Library for Amazon S3 Compatible Cloud Storage
+// Copyright 2023 MinIO, Inc.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -10,18 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Argument builders for [minio::s3::client::Client](crate::s3::client::Client) APIs
+//! S3 APIs for downloading objects.
 
-mod buckets;
-mod get_object;
-mod list_objects;
-mod listen_bucket_notification;
-mod object_content;
-mod put_object;
+use crate::s3::builders::GetObject;
 
-pub use buckets::*;
-pub use get_object::*;
-pub use list_objects::*;
-pub use listen_bucket_notification::*;
-pub use object_content::*;
-pub use put_object::*;
+use super::Client;
+
+impl Client {
+    /// Create a GetObject request builder.
+    pub fn get_object(&self, bucket: &str, object: &str) -> GetObject {
+        GetObject::new(bucket, object).client(self)
+    }
+}

--- a/src/s3/client/put_object.rs
+++ b/src/s3/client/put_object.rs
@@ -1,0 +1,88 @@
+// MinIO Rust Library for Amazon S3 Compatible Cloud Storage
+// Copyright 2023 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! S3 APIs for uploading objects.
+
+use std::path::Path;
+
+use super::Client;
+use crate::s3::{
+    builders::{
+        AbortMultipartUpload, CompleteMultipartUpload, CreateMultipartUpload, ObjectContent,
+        PutObject, PutObjectContent, SegmentedBytes, UploadPart,
+    },
+    types::Part,
+};
+
+impl Client {
+    /// Create a PutObject request builder. This is a lower-level API that
+    /// performs a non-multipart object upload.
+    pub fn put_object(&self, bucket: &str, object: &str, data: SegmentedBytes) -> PutObject {
+        PutObject::new(bucket, object, data).client(self)
+    }
+
+    /// Create a CreateMultipartUpload request builder.
+    pub fn create_multipart_upload(&self, bucket: &str, object: &str) -> CreateMultipartUpload {
+        CreateMultipartUpload::new(bucket, object).client(self)
+    }
+
+    pub fn abort_multipart_upload(
+        &self,
+        bucket: &str,
+        object: &str,
+        upload_id: &str,
+    ) -> AbortMultipartUpload {
+        AbortMultipartUpload::new(bucket, object, upload_id).client(self)
+    }
+
+    pub fn complete_multipart_upload(
+        &self,
+        bucket: &str,
+        object: &str,
+        upload_id: &str,
+        parts: Vec<Part>,
+    ) -> CompleteMultipartUpload {
+        CompleteMultipartUpload::new(bucket, object, upload_id, parts).client(self)
+    }
+
+    pub fn upload_part(
+        &self,
+        bucket: &str,
+        object: &str,
+        upload_id: &str,
+        part_number: u16,
+        data: SegmentedBytes,
+    ) -> UploadPart {
+        UploadPart::new(bucket, object, upload_id, part_number, data).client(self)
+    }
+
+    pub fn put_object_content(
+        &self,
+        bucket: &str,
+        object: &str,
+        content: impl Into<ObjectContent>,
+    ) -> PutObjectContent {
+        PutObjectContent::new(bucket, object, content).client(self)
+    }
+
+    pub fn put_object_from_file(
+        &self,
+        bucket: &str,
+        object: &str,
+        file_path: &Path,
+    ) -> PutObjectContent {
+        PutObjectContent::from_file(bucket, object, file_path).client(self)
+    }
+}

--- a/src/s3/error.rs
+++ b/src/s3/error.rs
@@ -79,11 +79,11 @@ pub enum Error {
     EmptyParts(String),
     InvalidRetentionMode(String),
     InvalidRetentionConfig(String),
-    InvalidMinPartSize(usize),
-    InvalidMaxPartSize(usize),
-    InvalidObjectSize(usize),
+    InvalidMinPartSize(u64),
+    InvalidMaxPartSize(u64),
+    InvalidObjectSize(u64),
     MissingPartSize,
-    InvalidPartCount(usize, usize, u16),
+    InvalidPartCount(u64, u64, u16),
     SseTlsRequired(Option<String>),
     InsufficientData(usize, usize),
     InvalidLegalHold(String),
@@ -111,6 +111,7 @@ pub enum Error {
     InvalidObjectLockConfig(String),
     NoClientProvided,
     TagDecodingError(String, String),
+    ContentLengthUnknown,
 }
 
 impl std::error::Error for Error {}
@@ -216,6 +217,7 @@ impl fmt::Display for Error {
             Error::InvalidObjectLockConfig(m) => write!(f, "{}", m),
             Error::NoClientProvided => write!(f, "no client provided"),
             Error::TagDecodingError(input, error_message) => write!(f, "tag decoding failed: {} on input '{}'", error_message, input),
+            Error::ContentLengthUnknown => write!(f, "content length is unknown"),
         }
     }
 }

--- a/src/s3/http.rs
+++ b/src/s3/http.rs
@@ -223,7 +223,7 @@ impl FromStr for BaseUrl {
 
     /// Convert a string to a BaseUrl.
     ///
-    /// Enables use of [`str`]'s [`parse`] method to create a [`BaseUrl`].
+    /// Enables use of [`str::parse`] method to create a [`BaseUrl`].
     ///
     /// # Examples
     ///

--- a/src/s3/response.rs
+++ b/src/s3/response.rs
@@ -32,14 +32,21 @@ use crate::s3::utils::{
 };
 
 mod buckets;
+mod get_object;
 mod list_objects;
 mod listen_bucket_notification;
+mod put_object;
 
 pub use buckets::{GetBucketVersioningResponse, ListBucketsResponse};
+pub use get_object::GetObjectResponse2;
 pub use list_objects::{
     ListObjectVersionsResponse, ListObjectsResponse, ListObjectsV1Response, ListObjectsV2Response,
 };
 pub use listen_bucket_notification::ListenBucketNotificationResponse;
+pub use put_object::{
+    AbortMultipartUploadResponse2, CompleteMultipartUploadResponse2,
+    CreateMultipartUploadResponse2, PutObjectResponse as PutObjectResponse2, UploadPartResponse2,
+};
 
 #[derive(Debug)]
 /// Base response for bucket operation

--- a/src/s3/response/get_object.rs
+++ b/src/s3/response/get_object.rs
@@ -1,0 +1,64 @@
+// MinIO Rust Library for Amazon S3 Compatible Cloud Storage
+// Copyright 2023 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+use tokio_stream::StreamExt;
+
+use crate::s3::{
+    builders::ObjectContent,
+    error::Error,
+    types::{FromS3Response, S3Request},
+};
+
+pub struct GetObjectResponse2 {
+    pub headers: http::HeaderMap,
+    pub region: String,
+    pub bucket_name: String,
+    pub object_name: String,
+    pub version_id: Option<String>,
+    pub content: ObjectContent,
+}
+
+#[async_trait]
+impl FromS3Response for GetObjectResponse2 {
+    async fn from_s3response<'a>(
+        req: S3Request<'a>,
+        response: reqwest::Response,
+    ) -> Result<Self, Error> {
+        let header_map = response.headers().clone();
+        let version_id = match header_map.get("x-amz-version-id") {
+            Some(v) => Some(v.to_str()?.to_string()),
+            None => None,
+        };
+
+        let content_length = response
+            .content_length()
+            .ok_or(Error::ContentLengthUnknown)?;
+        let body = response.bytes_stream().map(|result| {
+            result.map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))
+        });
+
+        let content = ObjectContent::new(body, Some(content_length));
+
+        Ok(GetObjectResponse2 {
+            headers: header_map,
+            region: req.region.unwrap_or("").to_string(),
+            bucket_name: req.bucket.unwrap().to_string(),
+            object_name: req.object.unwrap().to_string(),
+            version_id,
+            content,
+        })
+    }
+}

--- a/src/s3/response/put_object.rs
+++ b/src/s3/response/put_object.rs
@@ -1,0 +1,97 @@
+// MinIO Rust Library for Amazon S3 Compatible Cloud Storage
+// Copyright 2023 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+use bytes::Buf;
+use http::HeaderMap;
+use xmltree::Element;
+
+use crate::s3::{
+    error::Error,
+    types::{FromS3Response, S3Request},
+    utils::get_text,
+};
+
+#[derive(Debug, Clone)]
+pub struct PutObjectResponse {
+    pub headers: HeaderMap,
+    pub bucket_name: String,
+    pub object_name: String,
+    pub location: String,
+    pub etag: String,
+    pub version_id: Option<String>,
+}
+
+#[async_trait]
+impl FromS3Response for PutObjectResponse {
+    async fn from_s3response<'a>(
+        req: S3Request<'a>,
+        response: reqwest::Response,
+    ) -> Result<Self, Error> {
+        let header_map = response.headers();
+
+        Ok(PutObjectResponse {
+            headers: header_map.clone(),
+            bucket_name: req.bucket.unwrap().to_string(),
+            object_name: req.object.unwrap().to_string(),
+            location: req.region.unwrap_or("").to_string(),
+            etag: match header_map.get("etag") {
+                Some(v) => v.to_str()?.to_string().trim_matches('"').to_string(),
+                _ => String::new(),
+            },
+            version_id: match header_map.get("x-amz-version-id") {
+                Some(v) => Some(v.to_str()?.to_string()),
+                None => None,
+            },
+        })
+    }
+}
+
+pub type CreateMultipartUploadResponse2 = UploadIdResponse2;
+
+#[derive(Debug, Clone)]
+pub struct UploadIdResponse2 {
+    pub headers: HeaderMap,
+    pub region: String,
+    pub bucket_name: String,
+    pub object_name: String,
+    pub upload_id: String,
+}
+
+#[async_trait]
+impl FromS3Response for UploadIdResponse2 {
+    async fn from_s3response<'a>(
+        req: S3Request<'a>,
+        response: reqwest::Response,
+    ) -> Result<Self, Error> {
+        let header_map = response.headers().clone();
+        let body = response.bytes().await?;
+        let root = Element::parse(body.reader())?;
+
+        Ok(CreateMultipartUploadResponse2 {
+            headers: header_map.clone(),
+            region: req.region.unwrap_or("").to_string(),
+            bucket_name: req.bucket.unwrap().to_string(),
+            object_name: req.object.unwrap().to_string(),
+            upload_id: get_text(&root, "UploadId")?,
+        })
+    }
+}
+
+pub type AbortMultipartUploadResponse2 = UploadIdResponse2;
+
+pub type CompleteMultipartUploadResponse2 = PutObjectResponse;
+
+pub type UploadPartResponse2 = PutObjectResponse;

--- a/src/s3/sse.rs
+++ b/src/s3/sse.rs
@@ -19,7 +19,7 @@ use crate::s3::utils;
 use std::any::Any;
 
 /// Base server side encryption
-pub trait Sse: std::fmt::Debug {
+pub trait Sse: std::fmt::Debug + Send + Sync {
     fn headers(&self) -> utils::Multimap;
     fn copy_headers(&self) -> utils::Multimap;
     fn tls_required(&self) -> bool;

--- a/src/s3/types.rs
+++ b/src/s3/types.rs
@@ -15,6 +15,7 @@
 
 //! Various types for S3 API requests and responses
 
+use super::builders::SegmentedBytes;
 use super::client::Client;
 use crate::s3::error::Error;
 use crate::s3::utils::{
@@ -39,7 +40,7 @@ pub struct S3Request<'a> {
     pub object: Option<&'a str>,
     pub query_params: Multimap,
     pub headers: Multimap,
-    pub body: Option<Vec<u8>>,
+    pub body: Option<SegmentedBytes>,
 
     // Computed region
     inner_region: String,
@@ -85,7 +86,7 @@ impl<'a> S3Request<'a> {
         self
     }
 
-    pub fn body(mut self, body: Option<Vec<u8>>) -> Self {
+    pub fn body(mut self, body: Option<SegmentedBytes>) -> Self {
         self.body = body;
         self
     }
@@ -104,14 +105,14 @@ impl<'a> S3Request<'a> {
 
         // Execute the API request.
         self.client
-            .execute(
+            .execute2(
                 self.method.clone(),
                 &self.inner_region,
                 &mut self.headers,
                 &self.query_params,
                 self.bucket,
                 self.object,
-                self.body.as_ref().map(|x| x.as_slice()),
+                self.body.as_ref(),
             )
             .await
     }

--- a/src/s3/utils.rs
+++ b/src/s3/utils.rs
@@ -34,6 +34,8 @@ use xmltree::Element;
 
 use crate::s3::error::Error;
 
+use super::builders::SegmentedBytes;
+
 /// Date and time with UTC timezone
 pub type UtcTime = DateTime<Utc>;
 
@@ -71,9 +73,25 @@ pub fn sha256_hash(data: &[u8]) -> String {
     format!("{:x}", hasher.finalize())
 }
 
+pub fn sha256_hash_sb(sb: &SegmentedBytes) -> String {
+    let mut hasher = Sha256::new();
+    for data in sb.iter() {
+        hasher.update(data);
+    }
+    format!("{:x}", hasher.finalize())
+}
+
 /// Gets bas64 encoded MD5 hash of given data
 pub fn md5sum_hash(data: &[u8]) -> String {
     b64encode(md5compute(data).as_slice())
+}
+
+pub fn md5sum_hash_sb(sb: &SegmentedBytes) -> String {
+    let mut hasher = md5::Context::new();
+    for data in sb.iter() {
+        hasher.consume(data);
+    }
+    b64encode(hasher.compute().as_slice())
 }
 
 /// Gets current UTC time


### PR DESCRIPTION
- put_object_content -> streaming object uploads

- put_object_from_file -> upload file

- put_object, create_multipart_uload, abort_multipart_upload,
upload_part, complete_multipart_upload -> S3 APIs for single and
multipart uploads

- get_object -> streaming object downloads