### PR TITLE
Make request_parameters optional

### DIFF
--- a/src/s3/types.rs
+++ b/src/s3/types.rs
@@ -748,7 +748,7 @@ pub struct NotificationRecord {
     #[serde(alias = "userIdentity", default)]
     pub user_identity: UserIdentity,
     #[serde(alias = "requestParameters", default)]
-    pub request_parameters: RequestParameters,
+    pub request_parameters: Option<RequestParameters>,
     #[serde(alias = "responseElements", default)]
     pub response_elements: ResponseElements,
     #[serde(alias = "s3", default)]


### PR DESCRIPTION
Some events e.g. s3:Replication:OperationCompletedReplication send 'null' value in request_parameters and the deserialization can fail in such cases ('deault' doesn't help here)

Marking this field as optional will ensure that such events can also be deserialized without any error.