### PR TITLE
allow optional disk sync for download_object()

### DIFF
--- a/src/s3/args.rs
+++ b/src/s3/args.rs
@@ -2213,6 +2213,7 @@ pub struct DownloadObjectArgs<'a> {
     pub ssec: Option<&'a SseCustomerKey>,
     pub filename: &'a str,
     pub overwrite: bool,
+    pub disk_sync: bool,
 }
 
 impl<'a> DownloadObjectArgs<'a> {
@@ -2228,6 +2229,7 @@ impl<'a> DownloadObjectArgs<'a> {
         bucket_name: &'a str,
         object_name: &'a str,
         filename: &'a str,
+        disk_sync: bool,
     ) -> Result<DownloadObjectArgs<'a>, Error> {
         check_bucket_name(bucket_name, true)?;
 
@@ -2247,6 +2249,7 @@ impl<'a> DownloadObjectArgs<'a> {
             ssec: None,
             filename,
             overwrite: false,
+            disk_sync,
         })
     }
 }

--- a/src/s3/client.rs
+++ b/src/s3/client.rs
@@ -1536,7 +1536,9 @@ impl Client {
         while let Some(v) = resp.chunk().await? {
             file.write_all(&v)?;
         }
-        file.sync_all()?;
+        if args.disk_sync {
+            file.sync_all()?;
+        }
 
         Ok(DownloadObjectResponse {
             headers: resp.headers().clone(),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -522,7 +522,7 @@ impl ClientTest {
         let filename = rand_object_name();
         self.client
             .download_object(
-                &DownloadObjectArgs::new(&self.test_bucket, &object_name, &filename).unwrap(),
+                &DownloadObjectArgs::new(&self.test_bucket, &object_name, &filename, true).unwrap(),
             )
             .await
             .unwrap();
@@ -557,7 +557,7 @@ impl ClientTest {
         let filename = rand_object_name();
         self.client
             .download_object(
-                &DownloadObjectArgs::new(&self.test_bucket, &object_name, &filename).unwrap(),
+                &DownloadObjectArgs::new(&self.test_bucket, &object_name, &filename, true).unwrap(),
             )
             .await
             .unwrap();


### PR DESCRIPTION
Add an argument to allow not syncing the file to disk after get_object_old()  and leave it to the operating system's cache strategy. This is useful in performance sensitive scenarios.