### PR TITLE
Unexport unnecessary list functions

### DIFF
--- a/src/s3/builders/list_objects.rs
+++ b/src/s3/builders/list_objects.rs
@@ -19,10 +19,10 @@ use http::Method;
 use crate::s3::{
     client::Client,
     error::Error,
-    response::{
-        ListObjectVersionsResponse, ListObjectsResponse, ListObjectsV1Response,
-        ListObjectsV2Response,
+    response::list_objects::{
+        ListObjectVersionsResponse, ListObjectsV1Response, ListObjectsV2Response,
     },
+    response::ListObjectsResponse,
     types::{S3Api, S3Request, ToS3Request, ToStream},
     utils::{check_bucket_name, merge, Multimap},
 };
@@ -48,10 +48,9 @@ fn add_common_list_objects_query_params(
     }
 }
 
-/// Argument builder for ListObjectsV1 S3 API, created by
-/// [list_objects_v1()](crate::s3::client::Client::list_objects_v1).
+/// Argument for ListObjectsV1 S3 API.
 #[derive(Clone, Debug, Default)]
-pub struct ListObjectsV1 {
+struct ListObjectsV1 {
     client: Option<Client>,
 
     extra_headers: Option<Multimap>,
@@ -161,64 +160,9 @@ impl From<ListObjects> for ListObjectsV1 {
     }
 }
 
-impl ListObjectsV1 {
-    pub fn new(bucket: &str) -> Self {
-        Self {
-            bucket: bucket.to_owned(),
-            ..Default::default()
-        }
-    }
-
-    pub fn client(mut self, client: &Client) -> Self {
-        self.client = Some(client.clone());
-        self
-    }
-
-    pub fn extra_headers(mut self, extra_headers: Option<Multimap>) -> Self {
-        self.extra_headers = extra_headers;
-        self
-    }
-
-    pub fn extra_query_params(mut self, extra_query_params: Option<Multimap>) -> Self {
-        self.extra_query_params = extra_query_params;
-        self
-    }
-
-    pub fn region(mut self, region: Option<String>) -> Self {
-        self.region = region;
-        self
-    }
-
-    pub fn delimiter(mut self, delimiter: Option<String>) -> Self {
-        self.delimiter = delimiter;
-        self
-    }
-
-    pub fn disable_url_encoding(mut self, disable_url_encoding: bool) -> Self {
-        self.disable_url_encoding = disable_url_encoding;
-        self
-    }
-
-    pub fn max_keys(mut self, max_keys: Option<u16>) -> Self {
-        self.max_keys = max_keys;
-        self
-    }
-
-    pub fn prefix(mut self, prefix: Option<String>) -> Self {
-        self.prefix = prefix;
-        self
-    }
-
-    pub fn marker(mut self, marker: Option<String>) -> Self {
-        self.marker = marker;
-        self
-    }
-}
-
-/// Argument builder for ListObjectsV2 S3 API, created by
-/// [list_objects_v2()](crate::s3::client::Client::list_objects_v2).
+/// Argument for ListObjectsV2 S3 API.
 #[derive(Clone, Debug, Default)]
-pub struct ListObjectsV2 {
+struct ListObjectsV2 {
     client: Option<Client>,
 
     extra_headers: Option<Multimap>,
@@ -331,79 +275,9 @@ impl From<ListObjects> for ListObjectsV2 {
     }
 }
 
-impl ListObjectsV2 {
-    pub fn new(bucket: &str) -> Self {
-        Self {
-            bucket: bucket.to_owned(),
-            ..Default::default()
-        }
-    }
-
-    pub fn client(mut self, client: &Client) -> Self {
-        self.client = Some(client.clone());
-        self
-    }
-
-    pub fn extra_headers(mut self, extra_headers: Option<Multimap>) -> Self {
-        self.extra_headers = extra_headers;
-        self
-    }
-
-    pub fn extra_query_params(mut self, extra_query_params: Option<Multimap>) -> Self {
-        self.extra_query_params = extra_query_params;
-        self
-    }
-
-    pub fn region(mut self, region: Option<String>) -> Self {
-        self.region = region;
-        self
-    }
-
-    pub fn delimiter(mut self, delimiter: Option<String>) -> Self {
-        self.delimiter = delimiter;
-        self
-    }
-
-    pub fn disable_url_encoding(mut self, disable_url_encoding: bool) -> Self {
-        self.disable_url_encoding = disable_url_encoding;
-        self
-    }
-
-    pub fn max_keys(mut self, max_keys: Option<u16>) -> Self {
-        self.max_keys = max_keys;
-        self
-    }
-
-    pub fn prefix(mut self, prefix: Option<String>) -> Self {
-        self.prefix = prefix;
-        self
-    }
-
-    pub fn start_after(mut self, start_after: Option<String>) -> Self {
-        self.start_after = start_after;
-        self
-    }
-
-    pub fn continuation_token(mut self, continuation_token: Option<String>) -> Self {
-        self.continuation_token = continuation_token;
-        self
-    }
-
-    pub fn fetch_owner(mut self, fetch_owner: bool) -> Self {
-        self.fetch_owner = fetch_owner;
-        self
-    }
-
-    pub fn include_user_metadata(mut self, include_user_metadata: bool) -> Self {
-        self.include_user_metadata = include_user_metadata;
-        self
-    }
-}
-
-/// Argument builder for ListObjectVerions S3 API created by
-/// [list_object_versions()](crate::s3::client::Client::list_object_versions).
+/// Argument for ListObjectVerions S3 API
 #[derive(Clone, Debug, Default)]
-pub struct ListObjectVersions {
+struct ListObjectVersions {
     client: Option<Client>,
 
     extra_headers: Option<Multimap>,
@@ -510,70 +384,6 @@ impl From<ListObjects> for ListObjectVersions {
             version_id_marker: value.version_id_marker,
             include_user_metadata: value.include_user_metadata,
         }
-    }
-}
-
-impl ListObjectVersions {
-    pub fn new(bucket: &str) -> Self {
-        Self {
-            bucket: bucket.to_owned(),
-            ..Default::default()
-        }
-    }
-
-    pub fn client(mut self, client: &Client) -> Self {
-        self.client = Some(client.clone());
-        self
-    }
-
-    pub fn extra_headers(mut self, extra_headers: Option<Multimap>) -> Self {
-        self.extra_headers = extra_headers;
-        self
-    }
-
-    pub fn extra_query_params(mut self, extra_query_params: Option<Multimap>) -> Self {
-        self.extra_query_params = extra_query_params;
-        self
-    }
-
-    pub fn region(mut self, region: Option<String>) -> Self {
-        self.region = region;
-        self
-    }
-
-    pub fn delimiter(mut self, delimiter: Option<String>) -> Self {
-        self.delimiter = delimiter;
-        self
-    }
-
-    pub fn disable_url_encoding(mut self, disable_url_encoding: bool) -> Self {
-        self.disable_url_encoding = disable_url_encoding;
-        self
-    }
-
-    pub fn max_keys(mut self, max_keys: Option<u16>) -> Self {
-        self.max_keys = max_keys;
-        self
-    }
-
-    pub fn prefix(mut self, prefix: Option<String>) -> Self {
-        self.prefix = prefix;
-        self
-    }
-
-    pub fn key_marker(mut self, key_marker: Option<String>) -> Self {
-        self.key_marker = key_marker;
-        self
-    }
-
-    pub fn version_id_marker(mut self, version_id_marker: Option<String>) -> Self {
-        self.version_id_marker = version_id_marker;
-        self
-    }
-
-    pub fn include_user_metadata(mut self, include_user_metadata: bool) -> Self {
-        self.include_user_metadata = include_user_metadata;
-        self
     }
 }
 

--- a/src/s3/client/list_objects.rs
+++ b/src/s3/client/list_objects.rs
@@ -16,21 +16,9 @@
 //! S3 APIs for listing objects.
 
 use super::Client;
-use crate::s3::builders::{ListObjectVersions, ListObjects, ListObjectsV1, ListObjectsV2};
+use crate::s3::builders::ListObjects;
 
 impl Client {
-    pub fn list_objects_v1(&self, bucket: &str) -> ListObjectsV1 {
-        ListObjectsV1::new(bucket).client(self)
-    }
-
-    pub fn list_objects_v2(&self, bucket: &str) -> ListObjectsV2 {
-        ListObjectsV2::new(bucket).client(self)
-    }
-
-    pub fn list_object_versions(&self, bucket: &str) -> ListObjectVersions {
-        ListObjectVersions::new(bucket).client(self)
-    }
-
     /// List objects with version information optionally. This function handles
     /// pagination and returns a stream of results. Each result corresponds to
     /// the response of a single listing API call.

--- a/src/s3/response.rs
+++ b/src/s3/response.rs
@@ -33,16 +33,14 @@ use crate::s3::utils::{
 
 mod buckets;
 mod get_object;
-mod list_objects;
+pub(crate) mod list_objects;
 mod listen_bucket_notification;
 mod put_object;
 mod remove_objects;
 
 pub use buckets::{GetBucketVersioningResponse, ListBucketsResponse};
 pub use get_object::GetObjectResponse;
-pub use list_objects::{
-    ListObjectVersionsResponse, ListObjectsResponse, ListObjectsV1Response, ListObjectsV2Response,
-};
+pub use list_objects::ListObjectsResponse;
 pub use listen_bucket_notification::ListenBucketNotificationResponse;
 pub use put_object::{
     AbortMultipartUploadResponse2, CompleteMultipartUploadResponse2,


### PR DESCRIPTION
Unexports `list_objects_v1`, `list_objects_v2` and `list_object_versions` and associated request/response types.

These are not necessary as the higher level `list_objects()` can be used instead for equivalent functionality.