### PR TITLE
feat: allow multiple trust certs in cert file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["object-storage", "minio", "s3"]
 categories = ["api-bindings", "web-programming::http-client"]
 
 [dependencies.reqwest]
-version = "0.12.5"
+version = "0.12.8"
 default-features = false
 features = ["stream"]
 


### PR DESCRIPTION
The `.ssl_cert_file()` option now can read files with multiple certificate to trust. This is useful when using a single client instance to access many minio servers.