### PR TITLE
Remove copy_object !Send

### DIFF
--- a/src/s3/client.rs
+++ b/src/s3/client.rs
@@ -856,7 +856,7 @@ impl Client {
         Ok(part_count)
     }
 
-    #[async_recursion(?Send)]
+    #[async_recursion]
     pub async fn do_compose_object(
         &self,
         args: &mut ComposeObjectArgs<'_>,


### PR DESCRIPTION
## change
Use #[async_recursion] instead of #[async_recursion(?Send)], which make minio::s3::client::Client::copy_object work on tokio::spwan and axum reqwuest handler. If we still need Sync here, may switch to #[async_recursion(Sync)].

## async-recursion macro
#[async_recursion] modifies your function to return a boxed Future with a Send bound.
#[async_recursion(?Send)] modifies your function to return a boxed Future without a Send bound.
#[async_recursion(Sync)] modifies your function to return a boxed Future with a Send and Sync bound.

## demo
This is a master branch demo with Send limit, can't compile.
```rust
use minio::s3::{
    args::{CopyObjectArgs, CopySource},
    creds::StaticProvider,
    Client,
};

#[tokio::main]
async fn main() {
    tokio::spawn(copy_image(
        "bucket_from",
        "bucket_to",
        "filename".to_owned(),
    ));
}

pub async fn copy_image(bucket_from: &str, bucket_to: &str, filename: String) {
    let client = Client::new(
        "Base_Url".parse().unwrap(),
        Some(Box::new(StaticProvider::new(
            "MINIO_ACCESS_KEY",
            "MINIO_SECRET_KEY",
            None,
        ))),
        None,
        None,
    )
    .unwrap();
    let args = CopyObjectArgs::new(
        bucket_to,
        &filename,
        CopySource::new(bucket_from, &filename).unwrap(),
    )
    .unwrap();
    let _ = client.copy_object(&args).await;
}
```