### PR TITLE
Remove os_info dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ lazy_static = "1.5.0"
 log = "0.4.26"
 md5 = "0.7.0"
 multimap = "0.10.0"
-os_info = "3.10.0"
 percent-encoding = "2.3.1"
 rand = { version = "0.8.5", features = ["small_rng"] }
 regex = "1.11.1"

--- a/src/s3/client.rs
+++ b/src/s3/client.rs
@@ -127,11 +127,10 @@ impl ClientBuilder {
     pub fn build(self) -> Result<Client, Error> {
         let mut builder = reqwest::Client::builder().no_gzip();
 
-        let info = os_info::get();
         let mut user_agent = String::from("MinIO (")
-            + &info.os_type().to_string()
+            + std::env::consts::OS
             + "; "
-            + info.architecture().unwrap_or("unknown")
+            + std::env::consts::ARCH
             + ") minio-rs/"
             + env!("CARGO_PKG_VERSION");
 


### PR DESCRIPTION
os_info is too heavy, for the purposes of this library using the consts in std::env are enough

Fixes #107