### PR TITLE
optimize: use ring hash and hmac implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,11 @@ default-features = false
 features = ["stream"]
 
 [features]
-default = ["default-tls"]
+default = ["default-tls", "dep:hmac", "dep:sha2"]
 default-tls = ["reqwest/default-tls"]
 native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
+ring = ["dep:ring"]
 
 [dependencies]
 async-recursion = "1.1.1"
@@ -34,7 +35,7 @@ derivative = "2.2.0"
 env_logger = "0.11.7"
 futures-util = "0.3.31"
 hex = "0.4.3"
-hmac = "0.12.1"
+hmac = { version = "0.12.1", optional = true }
 #home = "0.5.9"
 http = "1.2.0"
 hyper = { version = "1.6.0", features = ["full"] }
@@ -45,9 +46,10 @@ multimap = "0.10.0"
 percent-encoding = "2.3.1"
 rand = { version = "0.8.5", features = ["small_rng"] }
 regex = "1.11.1"
+ring = { version = "0.17.14", optional = true, default-features = false, features = ["alloc"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
-sha2 = "0.10.8"
+sha2 = { version = "0.10.8", optional = true }
 tokio = { version = "1.44.0", features = ["full"] }
 tokio-stream = "0.1.17"
 tokio-util = { version = "0.7.13", features = ["io"] }


### PR DESCRIPTION
Ring has a faster hash implementation than sha2 crate. After profiling with samply and analysing flamegraph, hash computation call from sha256_hash_sb cpu usage went down to 2.6% from 13% just from this change.

<img width="546" alt="Screenshot 2025-03-19 at 9 27 10 AM" src="https://github.com/user-attachments/assets/b426e00e-a729-4d95-a040-9f1556867162" />

<img width="333" alt="Screenshot 2025-03-19 at 9 28 48 AM" src="https://github.com/user-attachments/assets/b1d99740-b404-49b3-968b-eda31276241a" />
