### PR TITLE
Update the README with additional information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,65 @@
 # MinIO Rust SDK for Amazon S3 Compatible Cloud Storage [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io) [![Sourcegraph](https://sourcegraph.com/github.com/minio/minio-rs/-/badge.svg)](https://sourcegraph.com/github.com/minio/minio-rs?badge) [![Apache V2 License](https://img.shields.io/badge/license-Apache%20V2-blue.svg)](https://github.com/minio/minio-rs/blob/master/LICENSE)
 
-MinIO Rust SDK is Simple Storage Service (aka S3) client to perform bucket and object operations to any Amazon S3 compatible object storage service.
+The MinIO Rust SDK is a Simple Storage Service (aka S3) client for performing bucket and object operations to any Amazon S3 compatible object storage service.
+It provides a strongly-typed, async-first interface to the MinIO and Amazon S3-compatible object storage APIs.
 
-For a complete list of APIs and examples, please take a look at the [MinIO Rust Client API Reference](https://minio-rs.min.io/)
+Each supported S3 operation has a corresponding request builder (for example: [`BucketExists`], [`PutObject`], [`UploadPartCopy`]), which allows users to configure request parameters using a fluent builder pattern.
+
+All request builders implement the [`S3Api`] trait, which provides the async [`send`](crate::s3::types::S3Api::send) method to execute the request and return a typed response.
+
+
+## Basic Usage
+
+```no_run
+use minio::s3::Client;
+use minio::s3::types::S3Api;
+use minio::s3::response::BucketExistsResponse;
+
+#[tokio::main]
+async fn main() {
+    let client: Client = Default::default(); // configure your client
+
+    let exists: BucketExistsResponse = client
+        .bucket_exists("my-bucket")
+        .send()
+        .await
+        .expect("request failed");
+
+    println!("Bucket exists: {}", exists.exists);
+}
+```
+
+## Features
+
+- Request builder pattern for ergonomic API usage
+- Full async/await support via [`tokio`]
+- Strongly-typed responses
+- Transparent error handling via `Result<T, Error>`
+
+
+## Design
+
+- Each API method on the [`Client`] returns a builder struct
+- Builders implement [`ToS3Request`] for request conversion and [`S3Api`] for execution
+- Responses implement [`FromS3Response`] for consistent deserialization
+
+#![allow(clippy::result_large_err)]
+#![allow(clippy::too_many_arguments)]
+pub mod s3;
+
+#[cfg(test)]
+#[macro_use]
+extern crate quickcheck;
+
 
 ## Examples
 
-Run the examples from the command line with:
+You can run the examples from the command line with:
 
 `cargo run --example <example_name>`
+
+The examples below cover several common operations.
+You can find the complete list of examples in the `examples` directory.
 
 ### file_uploader.rs
 
@@ -22,6 +73,7 @@ Run the examples from the command line with:
 ### object_prompt.rs 
 
 * [Prompt a file on MinIO](examples/object_prompt.rs)
+
 
 ## License
 This SDK is distributed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0), see [LICENSE](https://github.com/minio/minio-rs/blob/master/LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -43,14 +43,6 @@ async fn main() {
 - Builders implement [`ToS3Request`] for request conversion and [`S3Api`] for execution
 - Responses implement [`FromS3Response`] for consistent deserialization
 
-#![allow(clippy::result_large_err)]
-#![allow(clippy::too_many_arguments)]
-pub mod s3;
-
-#[cfg(test)]
-#[macro_use]
-extern crate quickcheck;
-
 
 ## Examples
 


### PR DESCRIPTION
Clarify and add additional information about the Rust SDK, in preparation for automated inclusion in the public documentation.

- Minor rework of existing text
- Incorporate documentation from src/lib.rs in the readme
