### PR TITLE
fix: replace Arc<Box<...>> credential-provider with Arc<...>

### DIFF
--- a/common/src/test_context.rs
+++ b/common/src/test_context.rs
@@ -59,7 +59,7 @@ impl TestContext {
             let static_provider = StaticProvider::new(&access_key, &secret_key, None);
             let client = Client::new(
                 base_url.clone(),
-                Some(Box::new(static_provider)),
+                Some(static_provider),
                 ssl_cert_file,
                 Some(ignore_cert_check),
             )
@@ -116,7 +116,7 @@ impl TestContext {
             let static_provider = StaticProvider::new(&access_key, &secret_key, None);
             let client = Client::new(
                 base_url.clone(),
-                Some(Box::new(static_provider)),
+                Some(static_provider),
                 Some(&*ssl_cert_file),
                 Some(ignore_cert_check),
             )

--- a/examples/common.rs
+++ b/examples/common.rs
@@ -16,7 +16,7 @@ pub fn create_client_on_play() -> Result<Client, Box<dyn std::error::Error + Sen
     );
 
     let client = ClientBuilder::new(base_url.clone())
-        .provider(Some(Box::new(static_provider)))
+        .provider(Some(static_provider))
         .build()?;
     Ok(client)
 }
@@ -29,7 +29,7 @@ pub fn create_client_on_localhost() -> Result<Client, Box<dyn std::error::Error 
     let static_provider = StaticProvider::new("minioadmin", "minioadmin", None);
 
     let client = ClientBuilder::new(base_url.clone())
-        .provider(Some(Box::new(static_provider)))
+        .provider(Some(static_provider))
         .build()?;
     Ok(client)
 }

--- a/examples/object_prompt.rs
+++ b/examples/object_prompt.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let static_provider = StaticProvider::new("admin", "admin", None);
 
     let client = ClientBuilder::new(base_url.clone())
-        .provider(Some(Box::new(static_provider)))
+        .provider(Some(static_provider))
         .ignore_cert_check(Some(true))
         .build()?;
 

--- a/examples/put_object.rs
+++ b/examples/put_object.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     );
 
     let client: Client = ClientBuilder::new("https://play.min.io".parse()?)
-        .provider(Some(Box::new(static_provider)))
+        .provider(Some(static_provider))
         .build()?;
 
     let resp: BucketExistsResponse = client.bucket_exists(&args.bucket).send().await.unwrap();

--- a/src/s3/client.rs
+++ b/src/s3/client.rs
@@ -123,7 +123,7 @@ pub const MAX_MULTIPART_COUNT: u16 = 10_000;
 #[derive(Debug, Default)]
 pub struct ClientBuilder {
     base_url: BaseUrl,
-    provider: Option<Arc<Box<(dyn Provider + Send + Sync + 'static)>>>,
+    provider: Option<Arc<dyn Provider + Send + Sync + 'static>>,
     ssl_cert_file: Option<PathBuf>,
     ignore_cert_check: Option<bool>,
     app_info: Option<(String, String)>,
@@ -139,12 +139,9 @@ impl ClientBuilder {
         }
     }
 
-    /// Set the credential provider. If not set anonymous access is used.
-    pub fn provider(
-        mut self,
-        provider: Option<Box<(dyn Provider + Send + Sync + 'static)>>,
-    ) -> Self {
-        self.provider = provider.map(Arc::new);
+    /// Set the credential provider. If not, set anonymous access is used.
+    pub fn provider<P: Provider + Send + Sync + 'static>(mut self, provider: Option<P>) -> Self {
+        self.provider = provider.map(|p| Arc::new(p) as Arc<dyn Provider + Send + Sync + 'static>);
         self
     }
 
@@ -245,11 +242,11 @@ impl Client {
     ///     "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG",
     ///     None,
     /// );
-    /// let client = Client::new(base_url, Some(Box::new(static_provider)), None, None).unwrap();
+    /// let client = Client::new(base_url, Some(static_provider), None, None).unwrap();
     /// ```
-    pub fn new(
+    pub fn new<P: Provider + Send + Sync + 'static>(
         base_url: BaseUrl,
-        provider: Option<Box<(dyn Provider + Send + Sync + 'static)>>,
+        provider: Option<P>,
         ssl_cert_file: Option<&Path>,
         ignore_cert_check: Option<bool>,
     ) -> Result<Self, Error> {
@@ -615,7 +612,7 @@ impl Client {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct SharedClientItems {
     pub(crate) base_url: BaseUrl,
-    pub(crate) provider: Option<Arc<Box<(dyn Provider + Send + Sync + 'static)>>>,
+    pub(crate) provider: Option<Arc<dyn Provider + Send + Sync + 'static>>,
     region_map: DashMap<String, String>,
     express: OnceLock<bool>,
 }


### PR DESCRIPTION
A `Box` is a pointer and an `Arc` is a smart pointer, we can remove one layer of indirection by directly using `Arc`. 
We can also remove the need for our caller to box / arc the input by making the respective functions generic over `Provider`.