### PR TITLE
bugfix: delete_and_purge_bucket add recursive delete

### DIFF
--- a/src/s3/client/delete_bucket.rs
+++ b/src/s3/client/delete_bucket.rs
@@ -74,6 +74,7 @@ impl Client {
             let mut stream = self
                 .list_objects(&bucket)
                 .include_versions(true)
+                .recursive(true)
                 .to_stream()
                 .await;
 


### PR DESCRIPTION
This PR enhances the delete_and_purge_bucket method by enabling recursive traversal when listing objects, ensuring nested items and versions are deleted.