### PR TITLE
fix: allow to use rustls while also using sha2 and hmac

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,11 @@ default-features = false
 features = ["stream"]
 
 [features]
-default = ["default-tls", "dep:hmac", "dep:sha2"]
+default = ["default-tls", "default-crypto"]
 default-tls = ["reqwest/default-tls"]
 native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
+default-crypto = ["dep:sha2", "dep:hmac"]
 ring = ["dep:ring"]
 
 [dependencies]


### PR DESCRIPTION
Fix https://github.com/minio/minio-rs/issues/174

This will allow you to specify hmac and sha2 dependencies, while disabling default features to enable rustls feature