### PR TITLE
Bugfix: whitespace in object name

### DIFF
--- a/common/src/cleanup_guard.rs
+++ b/common/src/cleanup_guard.rs
@@ -37,18 +37,18 @@ impl CleanupGuard {
 
 pub async fn cleanup(client: Client, bucket_name: &str) {
     tokio::select!(
-                _ = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
-                    eprintln!("Cleanup timeout after 60s while removing bucket {}", bucket_name);
-                },
-                outcome = client.delete_and_purge_bucket(bucket_name) => {
-                    match outcome {
-                        Ok(_) => {
-                            eprintln!("Bucket {} removed successfully", bucket_name);
-                        }
-                        Err(e) => {
-                            eprintln!("Error removing bucket {}: {:?}", bucket_name, e);
-                        }
-                    }
+        _ = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+            eprintln!("Cleanup timeout after 60s while removing bucket {}", bucket_name);
+        },
+        outcome = client.delete_and_purge_bucket(bucket_name) => {
+            match outcome {
+                Ok(_) => {
+                    //eprintln!("Bucket {} removed successfully", bucket_name);
                 }
+                Err(e) => {
+                    eprintln!("Error removing bucket {}: {:?}", bucket_name, e);
+                }
+            }
+        }
     );
 }

--- a/src/s3/builders/copy_object.rs
+++ b/src/s3/builders/copy_object.rs
@@ -26,7 +26,7 @@ use crate::s3::response::{
 use crate::s3::sse::{Sse, SseCustomerKey};
 use crate::s3::types::{Directive, PartInfo, Retention, S3Api, S3Request, ToS3Request};
 use crate::s3::utils::{
-    UtcTime, check_bucket_name, check_object_name, to_http_header_value, to_iso8601utc, urlencode,
+    UtcTime, check_bucket_name, check_object_name, to_http_header_value, to_iso8601utc, url_encode,
 };
 use async_recursion::async_recursion;
 use http::Method;
@@ -254,9 +254,9 @@ impl ToS3Request for CopyObjectInternal {
                     if !tagging.is_empty() {
                         tagging.push('&');
                     }
-                    tagging.push_str(&urlencode(key));
+                    tagging.push_str(&url_encode(key));
                     tagging.push('=');
-                    tagging.push_str(&urlencode(value));
+                    tagging.push_str(&url_encode(value));
                 }
                 if !tagging.is_empty() {
                     headers.add("x-amz-tagging", tagging);
@@ -285,7 +285,7 @@ impl ToS3Request for CopyObjectInternal {
             copy_source.push_str(&self.source.object);
             if let Some(v) = &self.source.version_id {
                 copy_source.push_str("?versionId=");
-                copy_source.push_str(&urlencode(v));
+                copy_source.push_str(&url_encode(v));
             }
             headers.add("x-amz-copy-source", copy_source);
 
@@ -1032,7 +1032,7 @@ impl ComposeSource {
         copy_source.push_str(&self.object);
         if let Some(v) = &self.version_id {
             copy_source.push_str("?versionId=");
-            copy_source.push_str(&urlencode(v));
+            copy_source.push_str(&url_encode(v));
         }
         headers.add("x-amz-copy-source", copy_source);
 
@@ -1155,9 +1155,9 @@ fn into_headers_copy_object(
             if !tagging.is_empty() {
                 tagging.push('&');
             }
-            tagging.push_str(&urlencode(key));
+            tagging.push_str(&url_encode(key));
             tagging.push('=');
-            tagging.push_str(&urlencode(value));
+            tagging.push_str(&url_encode(value));
         }
 
         if !tagging.is_empty() {

--- a/src/s3/builders/put_object.rs
+++ b/src/s3/builders/put_object.rs
@@ -29,7 +29,7 @@ use crate::s3::{
     },
     sse::Sse,
     types::{PartInfo, Retention, S3Api, S3Request, ToS3Request},
-    utils::{check_bucket_name, md5sum_hash, to_iso8601utc, urlencode},
+    utils::{check_bucket_name, md5sum_hash, to_iso8601utc, url_encode},
 };
 use bytes::{Bytes, BytesMut};
 use http::Method;
@@ -201,7 +201,7 @@ impl ToS3Request for AbortMultipartUpload {
 
         let headers: Multimap = self.extra_headers.unwrap_or_default();
         let mut query_params: Multimap = self.extra_query_params.unwrap_or_default();
-        query_params.add("uploadId", urlencode(&self.upload_id).to_string());
+        query_params.add("uploadId", url_encode(&self.upload_id).to_string());
 
         Ok(S3Request::new(self.client, Method::DELETE)
             .region(self.region)
@@ -885,9 +885,9 @@ fn into_headers_put_object(
             if !tagging.is_empty() {
                 tagging.push('&');
             }
-            tagging.push_str(&urlencode(key));
+            tagging.push_str(&url_encode(key));
             tagging.push('=');
-            tagging.push_str(&urlencode(value));
+            tagging.push_str(&url_encode(value));
         }
 
         if !tagging.is_empty() {

--- a/src/s3/multimap.rs
+++ b/src/s3/multimap.rs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::s3::utils::urlencode;
+use crate::s3::utils::url_encode;
 use lazy_static::lazy_static;
 use multimap::MultiMap;
 use regex::Regex;
 use std::collections::BTreeMap;
-pub use urlencoding::decode as urldecode;
 
 /// Multimap for string key and string value
 pub type Multimap = MultiMap<String, String>;
@@ -71,9 +70,9 @@ impl MultimapExt for Multimap {
                 if !query.is_empty() {
                     query.push('&');
                 }
-                query.push_str(&urlencode(key));
+                query.push_str(&url_encode(key));
                 query.push('=');
-                query.push_str(&urlencode(value));
+                query.push_str(&url_encode(value));
             }
         }
         query
@@ -94,9 +93,9 @@ impl MultimapExt for Multimap {
                         if !query.is_empty() {
                             query.push('&');
                         }
-                        query.push_str(&urlencode(key.as_str()));
+                        query.push_str(&url_encode(key.as_str()));
                         query.push('=');
-                        query.push_str(&urlencode(value));
+                        query.push_str(&url_encode(value));
                     }
                 }
                 None => todo!(), // This never happens.


### PR DESCRIPTION
The url_decode function now correctly decodes "a+b%2Bc" into "a b+c" instead of the incorrect "a+b+c".
Every function that uses either url_encode or url_decode now has dedicated tests to ensure correct handling of whitespace.