### PR TITLE
fix: correct two bugs in AppendObjectContent multipart append

### DIFF
--- a/src/s3/builders/append_object.rs
+++ b/src/s3/builders/append_object.rs
@@ -163,9 +163,6 @@ pub struct AppendObjectContent {
     content_stream: ContentStream,
     #[builder(default)]
     part_count: Option<u16>,
-    /// Value of `x-amz-write-offset-bytes`.
-    #[builder(default)]
-    offset_bytes: u64,
     /// Optional checksum algorithm for data integrity verification during append.
     ///
     /// When specified, computes checksums for appended data using the selected algorithm
@@ -191,21 +188,11 @@ pub type AppendObjectContentBldr = AppendObjectContentBuilder<(
     (),
     (),
     (),
-    (),
 )>;
 
 impl AppendObjectContent {
     pub async fn send(mut self) -> Result<AppendObjectResponse, Error> {
         check_sse(&self.sse, &self.client)?;
-
-        {
-            let mut headers: Multimap = match self.extra_headers {
-                Some(ref headers) => headers.clone(),
-                None => Multimap::new(),
-            };
-            headers.add(X_AMZ_WRITE_OFFSET_BYTES, self.offset_bytes.to_string());
-            self.extra_query_params = Some(headers);
-        }
 
         self.content_stream = std::mem::take(&mut self.input_content)
             .to_content_stream()
@@ -331,14 +318,14 @@ impl AppendObjectContent {
             //println!("AppendObjectResponse: object_size={:?}", resp.object_size);
 
             next_offset_bytes = resp.object_size();
+            last_resp = Some(resp);
 
             // Finally check if we are done.
             if buffer_size < part_size {
                 done = true;
-                last_resp = Some(resp);
             }
         }
-        Ok(last_resp.unwrap())
+        Ok(last_resp.expect("send_mpa always uploads at least one part"))
     }
 }
 // endregion: append-object-content

--- a/tests/s3/append_object.rs
+++ b/tests/s3/append_object.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use minio::s3::builders::ObjectContent;
+use minio::s3::builders::{MIN_PART_SIZE, ObjectContent};
 use minio::s3::error::{Error, S3ServerError};
 use minio::s3::minio_error_response::MinioErrorCode;
 use minio::s3::response::{
@@ -541,4 +541,44 @@ async fn append_object_content_3(ctx: TestContext, bucket: BucketName) {
 
     sender_handle.await.unwrap();
     uploader_handler.await.unwrap();
+}
+
+/// Regression test: content that is an exact multiple of MIN_PART_SIZE triggers multipart append
+/// where every part fills the buffer completely. The old code exited the loop without setting
+/// last_resp, causing a panic. Verifies the fix returns Ok instead of panicking.
+#[minio_macros::test(skip_if_not_express)]
+async fn append_object_content_exact_part_size_multiple(ctx: TestContext, bucket: BucketName) {
+    let object = rand_object_name();
+
+    let initial_content = "initial";
+    let initial_size = initial_content.len() as u64;
+
+    create_object_helper(initial_content, &bucket, &object, &ctx).await;
+
+    // 2 * MIN_PART_SIZE: both parts are exactly full-sized, exercising the case
+    // where buffer_size == part_size on every iteration and last_resp was never set.
+    let append_size = 2 * MIN_PART_SIZE;
+    let data: ObjectContent =
+        ObjectContent::new_from_stream(RandSrc::new(append_size), Some(append_size));
+    let resp: AppendObjectResponse = ctx
+        .client
+        .append_object_content(&bucket, &object, data)
+        .unwrap()
+        .build()
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.bucket(), Some(&bucket));
+    assert_eq!(resp.object(), Some(&object));
+    assert_eq!(resp.object_size(), initial_size + append_size);
+
+    let resp: StatObjectResponse = ctx
+        .client
+        .stat_object(&bucket, &object)
+        .unwrap()
+        .build()
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.size().unwrap(), initial_size + append_size);
 }


### PR DESCRIPTION
## Summary

- **Panic on exact-multiple sizes**: `last_resp` in `send_mpa` was only set when `buffer_size < part_size`. When content is an exact multiple of `part_size`, all parts upload with full-size buffers, `last_resp` stays `None`, and the final `last_resp.unwrap()` panics. Fixed by assigning `last_resp` on every successful upload.

- **Headers placed in query params**: `AppendObjectContent::send()` built a `Multimap` from `extra_headers`, added `X_AMZ_WRITE_OFFSET_BYTES` to it, then assigned it to `self.extra_query_params` instead of `self.extra_headers`. This overwrote any caller-supplied query params and put a header in the query string. Since `X_AMZ_WRITE_OFFSET_BYTES` is already set correctly per-part inside `AppendObject::to_s3request`, the block is removed entirely.

- The now-unused `offset_bytes` field on `AppendObjectContent` is also removed; the real write offset is always derived from `stat_object`.

## Test plan

- [ ] Existing unit tests pass (`cargo test --lib`)
- [ ] Manual test: upload content whose size is an exact multiple of the part size via `append_object_content` — previously panicked, now completes successfully