### PR TITLE
Release v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minio"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 authors = ["MinIO Dev Team <dev@min.io>"]
 description = "MinIO SDK for Amazon S3 compatible object storage access"


### PR DESCRIPTION
## Summary
- Bump package version from `0.3.0` to `0.4.0` in `Cargo.toml` ahead of the 0.4.0 tag and crates.io publish.

No code changes beyond the version bump. Release notes below for review — I'll use these as the GitHub release body once the tag is cut.

---

## Proposed release notes (v0.4.0)

### Breaking changes
- **Typed wrapper structs for string parameters** — most API methods now accept `TryInto<BucketName>` / `TryInto<ObjectKey>` / etc., so `&str` / `String` / pre-validated typed values all work at call sites. Validation happens once at the boundary. (#200)
- **Error type cleanup and reorganization.** (#179)
- **Request builders migrated to the `TypedBuilder` derive macro** — builder surface is regenerated; some method shapes may differ. (#184)
- **Credential provider type** simplified from `Arc<Box<dyn CredentialProvider>>` to `Arc<dyn CredentialProvider>`. (#164)
- **`DeleteObjects` batching** lowered from 10,000 to 1,000 keys per request to match the documented S3 limit. (#208)
- **Default multipart part size** raised to 64 MiB (from the previous default, via an intermediate 16 MiB step). (#207, #209)

### New features
- **Request hooks infrastructure** — intercept and modify in-flight requests, e.g. for load balancing. (#188, see `examples/load_balancing_with_hooks.rs`)
- **Additional checksum algorithms**: CRC32, CRC32C, SHA1, SHA256, and CRC64NVME. (#195)

### Performance
- Signing key memoization; `stat_object` now issues HEAD instead of GET. (#197)
- Eliminated intermediate `Vec<Bytes>` allocation during HTTP request body preparation. (#192)

### Fixes
- Virtual-hosted-style bucket requests now use `/` as the URL path. (#205)
- Two bugs fixed in `AppendObjectContent` multipart append. (#206)
- Correct part size in multipart copy; added missing response properties. (#196)
- `rustls` can now be used alongside `sha2` and `hmac`. (#175)
- Form-decoding (not percent-decoding) is used for whitespace in URLs during signing. (#178)
- `delete_and_purge_bucket` deletes objects recursively. (#166)
- HTTP header constants use proper capitalization. (#186)

### Housekeeping / internal
- Codebase consolidation and test infrastructure refresh. (#194)
- Test macro for parameterized integration tests. (#170)
- Duplicated code removed; lazy response evaluation. (#162)
- Dropped direct `tokio` / `tokio-stream` / `tokio-util` dependencies; library internals now use runtime-agnostic `futures-util` / `async-stream` combinators. Tokio is still pulled in transitively via `reqwest` / `hyper`, so a tokio-compatible runtime is still required at the call site. (#167)
- Clippy cleanup and unused-import pruning. (#182, #177)
- `copy_object` documentation. (#172)
- Added `.github/copilot-instructions.md`. (#191)

Full commit range: `v0.3.0..release-v0.4.0` (26 commits).

---

## Test plan
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all-targets` — zero warnings
- [x] `cargo test --doc` passes
- [x] `cargo test --lib --bins` passes
- [x] `cargo build --all-targets` succeeds
- [ ] `cargo publish --dry-run` (to run before tagging)
- [ ] Tag `v0.4.0` after merge and publish to crates.io
- [ ] Run `./deploy-docs.sh` to refresh rustdoc on `gh-pages`
