### PR TITLE
fix: x-amz-* starts_with conditions in add_starts_with_condition

### DIFF
--- a/src/s3/builders/get_presigned_policy_form_data.rs
+++ b/src/s3/builders/get_presigned_policy_form_data.rs
@@ -229,7 +229,7 @@ impl PostPolicy {
         let v = PostPolicy::trim_dollar(element);
         if v.eq_ignore_ascii_case("success_action_status")
             || v.eq_ignore_ascii_case("content-length-range")
-            || (v.starts_with("x-amz-") && v.starts_with("x-amz-meta-"))
+            || (v.starts_with("x-amz-") && !v.starts_with("x-amz-meta-"))
         {
             return Err(ValidationErr::PostPolicyError(format!(
                 "{element} is unsupported for starts-with condition",


### PR DESCRIPTION
- fix `x-amz-meta-*` user metadata being rejected
- fix accepting any `x-amz-*` headers that are not `x-amz-meta-*`