### PR TITLE
feat: use public AIStor build + free license in CI/CD

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,12 @@ jobs:
         run: cargo clippy --all-targets --all-features --workspace -- -D warnings
   test-multi-thread:
     runs-on: ubuntu-latest
+    # AIStor requires a valid license for ALL S3 operations. The secret is
+    # withheld from PRs originating in forks, so these server-backed tests
+    # cannot pass there until fork handling is decided (see start-server.sh,
+    # which fails fast when no valid license is present).
+    env:
+      MINIO_LICENSE: ${{ secrets.AISTOR_LICENSE }}
     steps:
       - uses: actions/checkout@v4
       - name: Run tests
@@ -45,6 +51,8 @@ jobs:
           MINIO_TEST_TOKIO_RUNTIME_FLAVOR="multi_thread" cargo test -- --nocapture
   test-current-thread:
     runs-on: ubuntu-latest
+    env:
+      MINIO_LICENSE: ${{ secrets.AISTOR_LICENSE }}
     steps:
       - uses: actions/checkout@v4
       - name: Run tests

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -180,6 +180,32 @@ cargo test --lib property_tests
 cargo test --test integration_tests -- --ignored
 ```
 
+CI starts a local server with `tests/start-server.sh`, which downloads the
+**AIStor** build (`dl.min.io/aistor/minio/...`) rather than the OSS server so
+that licensed features (Express, Inventory, Tables) can be exercised.
+
+**A valid license is required for all S3 operations.** Unlike the OSS server,
+AIStor denies every S3 request when no valid license is present (the server
+logs `No valid license found, running in offline mode`). A missing, empty,
+stale, or invalid license therefore fails the entire integration suite, not
+just licensed-feature tests. `start-server.sh` detects this and fails fast with
+a clear message.
+
+Provide the license via the `MINIO_LICENSE` environment variable before
+launching the server:
+```bash
+export MINIO_LICENSE="<your-aistor-license-jwt>"
+./tests/start-server.sh
+```
+
+In the canonical repository's CI the license is supplied by the
+**`AISTOR_LICENSE`** GitHub Actions secret, which the workflow maps onto the
+`MINIO_LICENSE` environment variable the server reads. GitHub withholds secrets
+from workflows triggered by PRs from forks, so server-backed integration tests
+cannot run on fork PRs; fork contributors set their own `AISTOR_LICENSE` secret
+(or local `MINIO_LICENSE` env var) to run them. A license can be obtained from
+min.io.
+
 ### Coverage Report
 ```bash
 cargo llvm-cov --lib --tests --html --output-dir target/coverage

--- a/tests/start-server.sh
+++ b/tests/start-server.sh
@@ -3,22 +3,51 @@
 set -x
 set -e
 
-wget --quiet https://dl.min.io/server/minio/release/linux-amd64/minio
+wget --quiet https://dl.min.io/aistor/minio/release/linux-amd64/minio
 chmod +x minio
 
 echo "MinIO Server Version:"
 ./minio --version
 
+# Disable xtrace around any expansion of MINIO_LICENSE so set -x never echoes
+# the token into CI logs; only its presence/absence is reported.
+set +x
+if [ -n "${MINIO_LICENSE:-}" ]; then
+    echo "MINIO_LICENSE detected; starting AIStor with a license."
+else
+    echo "WARNING: MINIO_LICENSE is empty. AIStor denies all S3 operations without a valid license."
+fi
+set -x
+
 mkdir -p /tmp/certs
 cp ./tests/public.crt ./tests/private.key /tmp/certs/
 
+# MINIO_LICENSE is inherited from the environment when present (CI secret).
+# SUBNET defaults are forced off so the server makes no outbound calls in CI.
+# Server output is teed to a log file so the license status can be inspected.
+SERVER_LOG=/tmp/minio-server.log
 (MINIO_CI_CD=true \
     MINIO_SITE_REGION=us-east-1 \
+    MINIO_SUBNET_DISABLE_ALERT=on \
+    MINIO_SUBNET_RENEWAL=off \
     MINIO_NOTIFY_WEBHOOK_ENABLE_miniojavatest=on \
     MINIO_NOTIFY_WEBHOOK_ENDPOINT_miniojavatest=http://example.org/ \
-    ./minio server /tmp/test-xl/{1...4}/ --certs-dir /tmp/certs/ &)
+    ./minio server /tmp/test-xl/{1...4}/ --certs-dir /tmp/certs/ 2>&1 | tee "$SERVER_LOG" &)
 
 sleep 10
+
+# AIStor requires a valid license for ALL S3 operations. A missing, empty,
+# stale, or invalid license puts the server in offline mode where every
+# request is denied. Fail fast with a clear message instead of letting the
+# whole suite fail with opaque access-denied errors.
+if grep -q "No valid license found" "$SERVER_LOG"; then
+    echo "ERROR: AIStor reports no valid license -- all S3 operations are denied."
+    echo "       Check the MINIO_LICENSE value (from the AISTOR_LICENSE CI secret):"
+    echo "       it is missing, empty, stale, or invalid."
+    echo "----- server log (tail) -----"
+    tail -n 40 "$SERVER_LOG" || true
+    exit 1
+fi
 
 
 


### PR DESCRIPTION
  CI downloaded the OSS MinIO server (dl.min.io/server/minio/...), which
  omits the licensed features (Express, Inventory, Tables), so those SDK
  code paths could never be exercised. The original blocker — no license
  key available to public-SDK CI — is gone: there is now a public,
  unauthenticated AIStor download channel, and a free AIStor license can
  unlock the licensed features.

  - tests/start-server.sh: download the AIStor build (dl.min.io/aistor/minio/release/linux-amd64/minio) instead of OSS; log whether MINIO_LICENSE is present; force SUBNET defaults off (MINIO_SUBNET_DISABLE_ALERT=on, MINIO_SUBNET_RENEWAL=off) so the server makes no outbound calls in CI. The license passes through from the environment only when set.
  - .github/workflows/rust.yml: expose MINIO_LICENSE from the repo secret to both test jobs. It is empty on PRs from forks (GitHub withholds secrets from fork-triggered runs), so the core S3 suite still runs there; fork contributors supply their own license.
  - docs/TESTING_STRATEGY.md: document the AIStor binary, setting MINIO_LICENSE locally, and the fork-vs-canonical secret behavior.

  Scope is infra/enabler only; the Express/Inventory/Tables integration
  tests land with the corresponding SDK client code. Verified the AIStor
  build (RELEASE.2026-05-28T20-50-32Z) starts and serves core S3 without a
  license: health returns 200 and the bucket_create/bucket_delete/
  list_buckets integration tests pass against it.