### PR TITLE
feat: storage class on writes, checksum mode on GET/HEAD, credential chain

### DIFF
--- a/examples/storage_class_checksum.rs
+++ b/examples/storage_class_checksum.rs
@@ -1,0 +1,197 @@
+// MinIO Rust Library for Amazon S3 Compatible Cloud Storage
+// Copyright 2025 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Verifies storage-class on writes and checksum-mode on GET/HEAD against a
+//! live server (defaults to play.min.io). Run with:
+//!
+//! ```not_rust
+//! cargo run --example storage_class_checksum
+//! ```
+
+use futures_util::StreamExt;
+use minio::s3::builders::{CopySource, ObjectContent};
+use minio::s3::response_traits::HasChecksumHeaders;
+use minio::s3::types::{BucketName, ObjectKey, S3Api, ToStream};
+use minio::s3::utils::ChecksumAlgorithm;
+use minio::s3::{MinioClient, MinioClientBuilder, creds::StaticProvider};
+use uuid::Uuid;
+
+const STORAGE_CLASS: &str = "REDUCED_REDUNDANCY";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let endpoint =
+        std::env::var("SERVER_ENDPOINT").unwrap_or_else(|_| "https://play.min.io".to_string());
+    let access_key =
+        std::env::var("ACCESS_KEY").unwrap_or_else(|_| "Q3AM3UQ867SPQQA43P2F".to_string());
+    let secret_key = std::env::var("SECRET_KEY")
+        .unwrap_or_else(|_| "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG".to_string());
+
+    let client: MinioClient = MinioClientBuilder::new(endpoint.parse()?)
+        .provider(Some(StaticProvider::new(&access_key, &secret_key, None)))
+        .build()?;
+
+    let bucket = format!("test-sc-cs-{}", Uuid::new_v4());
+    client.create_bucket(&bucket)?.build().send().await?;
+    println!("created bucket {bucket}");
+
+    let mut failures = 0;
+
+    // --- storage_class via put_object_content (single-shot) ---
+    let object = "single.txt";
+    client
+        .put_object_content(&bucket, object, ObjectContent::from("hello storage class"))?
+        .storage_class(Some(STORAGE_CLASS.to_string()))
+        .checksum_algorithm(ChecksumAlgorithm::CRC32C)
+        .build()
+        .send()
+        .await?;
+
+    let listed = find_storage_class(&client, &bucket, object).await?;
+    if listed.as_deref() == Some(STORAGE_CLASS) {
+        println!("PASS put_object_content storage_class -> {listed:?}");
+    } else {
+        println!("FAIL put_object_content storage_class -> {listed:?} (expected {STORAGE_CLASS})");
+        failures += 1;
+    }
+
+    // --- storage_class via the single-shot PutObject builder ---
+    let object_put = "put.txt";
+    let data = minio::s3::segmented_bytes::SegmentedBytes::from("hello put object".to_string());
+    client
+        .put_object(&bucket, object_put, data)?
+        .build()
+        .storage_class(STORAGE_CLASS)
+        .send()
+        .await?;
+    let listed_put = find_storage_class(&client, &bucket, object_put).await?;
+    if listed_put.as_deref() == Some(STORAGE_CLASS) {
+        println!("PASS put_object storage_class -> {listed_put:?}");
+    } else {
+        println!("FAIL put_object storage_class -> {listed_put:?} (expected {STORAGE_CLASS})");
+        failures += 1;
+    }
+
+    // --- storage_class through the multipart path (CreateMultipartUpload) ---
+    // 6 MiB with a 5 MiB part size forces a 2-part multipart upload, exercising
+    // the CreateMultipartUpload branch (storage class set on create, not parts).
+    let object_mpu = "multipart.bin";
+    client
+        .put_object_content(
+            &bucket,
+            object_mpu,
+            ObjectContent::from(vec![b'x'; 6 * 1024 * 1024]),
+        )?
+        .part_size(Some(5 * 1024 * 1024_u64))
+        .storage_class(Some(STORAGE_CLASS.to_string()))
+        .build()
+        .send()
+        .await?;
+    let listed_mpu = find_storage_class(&client, &bucket, object_mpu).await?;
+    if listed_mpu.as_deref() == Some(STORAGE_CLASS) {
+        println!("PASS multipart storage_class -> {listed_mpu:?}");
+    } else {
+        println!("FAIL multipart storage_class -> {listed_mpu:?} (expected {STORAGE_CLASS})");
+        failures += 1;
+    }
+
+    // --- storage_class on CopyObject ---
+    let object_copy = "copy.txt";
+    client
+        .copy_object(&bucket, object_copy)?
+        .source(
+            CopySource::builder()
+                .bucket(BucketName::new(&bucket)?)
+                .object(ObjectKey::new(object)?)
+                .build(),
+        )
+        .storage_class(Some(STORAGE_CLASS.to_string()))
+        .build()
+        .send()
+        .await?;
+    let listed_copy = find_storage_class(&client, &bucket, object_copy).await?;
+    if listed_copy.as_deref() == Some(STORAGE_CLASS) {
+        println!("PASS copy_object storage_class -> {listed_copy:?}");
+    } else {
+        println!("FAIL copy_object storage_class -> {listed_copy:?} (expected {STORAGE_CLASS})");
+        failures += 1;
+    }
+
+    // --- checksum_mode on stat_object (HEAD) ---
+    let stat = client
+        .stat_object(&bucket, object)?
+        .enable_checksum(true)
+        .build()
+        .send()
+        .await?;
+    let stat_checksum = stat.get_checksum(ChecksumAlgorithm::CRC32C);
+    if stat_checksum.is_some() {
+        println!("PASS stat_object checksum_mode -> crc32c {stat_checksum:?}");
+    } else {
+        println!("FAIL stat_object checksum_mode -> no checksum returned");
+        failures += 1;
+    }
+
+    // --- checksum_mode on get_object (GET) ---
+    let get = client
+        .get_object(&bucket, object)?
+        .enable_checksum(true)
+        .build()
+        .send()
+        .await?;
+    let get_checksum = get.get_checksum(ChecksumAlgorithm::CRC32C);
+    if get_checksum.is_some() {
+        println!("PASS get_object checksum_mode -> crc32c {get_checksum:?}");
+    } else {
+        println!("FAIL get_object checksum_mode -> no checksum returned");
+        failures += 1;
+    }
+
+    // --- cleanup ---
+    for obj in [object, object_put, object_mpu, object_copy] {
+        let _ = client.delete_object(&bucket, obj)?.build().send().await;
+    }
+    client.delete_bucket(&bucket)?.build().send().await?;
+    println!("removed bucket {bucket}");
+
+    if failures == 0 {
+        println!("\nALL CHECKS PASSED");
+        Ok(())
+    } else {
+        Err(format!("{failures} check(s) failed").into())
+    }
+}
+
+async fn find_storage_class(
+    client: &MinioClient,
+    bucket: &str,
+    object: &str,
+) -> Result<Option<String>, Box<dyn std::error::Error + Send + Sync>> {
+    let mut stream = client
+        .list_objects(bucket)
+        .unwrap()
+        .recursive(true)
+        .build()
+        .to_stream()
+        .await;
+    while let Some(items) = stream.next().await {
+        for item in items?.contents {
+            if item.name == object {
+                return Ok(item.storage_class);
+            }
+        }
+    }
+    Ok(None)
+}

--- a/src/s3/builders/copy_object.rs
+++ b/src/s3/builders/copy_object.rs
@@ -332,6 +332,11 @@ pub struct CopyObject {
     /// SHA1, SHA256, CRC64NVME. The checksum value is included in response headers for verification.
     #[builder(default, setter(into))]
     checksum_algorithm: Option<crate::s3::utils::ChecksumAlgorithm>,
+    /// Optional storage class for the destination object, sent as the
+    /// `X-Amz-Storage-Class` header. Applies to both the direct copy and the
+    /// multipart (compose) path used for sources larger than 5 GiB.
+    #[builder(default, setter(into))]
+    storage_class: Option<String>,
 }
 
 /// Builder type for [`CopyObject`] that is returned by [`MinioClient::copy_object`](crate::s3::client::MinioClient::copy_object).
@@ -354,6 +359,7 @@ pub type CopyObjectBldr = CopyObjectBuilder<(
     (),
     (),
     (),
+    (),
 )>;
 
 impl CopyObject {
@@ -361,9 +367,15 @@ impl CopyObject {
     ///
     /// Functionally related to the [S3Api::send()](crate::s3::types::S3Api::send) method, but
     /// specifically tailored for the `CopyObject` operation.
-    pub async fn send(self) -> Result<CopyObjectResponse, Error> {
+    pub async fn send(mut self) -> Result<CopyObjectResponse, Error> {
         check_sse(&self.sse, &self.client)?;
         check_ssec(&self.source.ssec, &self.client)?;
+
+        if let Some(storage_class) = self.storage_class.take() {
+            let mut headers = self.headers.take().unwrap_or_default();
+            headers.add(X_AMZ_STORAGE_CLASS, storage_class);
+            self.headers = Some(headers);
+        }
 
         let source = self.source.clone();
 

--- a/src/s3/builders/get_object.rs
+++ b/src/s3/builders/get_object.rs
@@ -59,6 +59,13 @@ pub struct GetObject {
     modified_since: Option<UtcTime>,
     #[builder(default, setter(into))]
     unmodified_since: Option<UtcTime>,
+
+    /// When true, requests the server to return the object's stored checksum by
+    /// sending `x-amz-checksum-mode: ENABLED`. For multipart objects the value
+    /// is the checksum of part checksums. The checksum is exposed on the
+    /// response via [`HasChecksumHeaders`](crate::s3::response_traits::HasChecksumHeaders).
+    #[builder(default = false)]
+    enable_checksum: bool,
 }
 
 /// Builder type alias for [`GetObject`].
@@ -71,6 +78,7 @@ pub type GetObjectBldr = GetObjectBuilder<(
     (),
     (BucketName,),
     (ObjectKey,),
+    (),
     (),
     (),
     (),
@@ -128,6 +136,10 @@ impl ToS3Request for GetObject {
             if let Some(v) = &self.ssec {
                 headers.add_multimap(v.headers());
             }
+
+            if self.enable_checksum {
+                headers.add(X_AMZ_CHECKSUM_MODE, "ENABLED");
+            }
         }
 
         let mut query_params: Multimap = self.extra_query_params.unwrap_or_default();
@@ -145,5 +157,44 @@ impl ToS3Request for GetObject {
             .query_params(query_params)
             .headers(headers)
             .build())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::s3::creds::StaticProvider;
+    use crate::s3::http::BaseUrl;
+
+    fn test_client() -> MinioClient {
+        let base_url = "http://localhost:9000/".parse::<BaseUrl>().unwrap();
+        let provider = StaticProvider::new("minioadmin", "minioadmin", None);
+        MinioClient::new(base_url, Some(provider), None, None).unwrap()
+    }
+
+    #[test]
+    fn enable_checksum_emits_header() {
+        let req = test_client()
+            .get_object("test-bucket", "test-object")
+            .unwrap()
+            .enable_checksum(true)
+            .build()
+            .to_s3request()
+            .unwrap();
+        assert_eq!(
+            req.headers.get(X_AMZ_CHECKSUM_MODE).map(String::as_str),
+            Some("ENABLED")
+        );
+    }
+
+    #[test]
+    fn checksum_header_absent_by_default() {
+        let req = test_client()
+            .get_object("test-bucket", "test-object")
+            .unwrap()
+            .build()
+            .to_s3request()
+            .unwrap();
+        assert!(req.headers.get(X_AMZ_CHECKSUM_MODE).is_none());
     }
 }

--- a/src/s3/builders/put_object.rs
+++ b/src/s3/builders/put_object.rs
@@ -74,6 +74,11 @@ pub struct CreateMultipartUpload {
     /// The checksum is included in response headers for verification.
     #[builder(default, setter(into))]
     checksum_algorithm: Option<ChecksumAlgorithm>,
+
+    /// Optional storage class for the object, sent as the `X-Amz-Storage-Class`
+    /// header. Applies to the whole object assembled from the multipart upload.
+    #[builder(default, setter(into))]
+    storage_class: Option<String>,
 }
 
 /// Builder type for [`CreateMultipartUpload`] that is returned by [`MinioClient::create_multipart_upload`](crate::s3::client::MinioClient::create_multipart_upload).
@@ -86,6 +91,7 @@ pub type CreateMultipartUploadBldr = CreateMultipartUploadBuilder<(
     (),
     (BucketName,),
     (ObjectKey,),
+    (),
     (),
     (),
     (),
@@ -113,6 +119,10 @@ impl ToS3Request for CreateMultipartUpload {
 
         if let Some(algorithm) = self.checksum_algorithm {
             headers.add(X_AMZ_CHECKSUM_ALGORITHM, algorithm.as_str().to_string());
+        }
+
+        if let Some(storage_class) = &self.storage_class {
+            headers.add(X_AMZ_STORAGE_CLASS, storage_class);
         }
 
         Ok(S3Request::builder()
@@ -398,6 +408,13 @@ pub struct UploadPart {
     /// Defaults to false for backwards compatibility.
     #[builder(default = false)]
     use_signed_streaming: bool,
+
+    /// Optional storage class for the object, sent as the `X-Amz-Storage-Class`
+    /// header. Only meaningful for a single-part `PutObject`; for multipart
+    /// uploads the storage class is set on `CreateMultipartUpload`, not on
+    /// individual parts.
+    #[builder(default, setter(into))]
+    storage_class: Option<String>,
 }
 
 /// Builder type for [`UploadPart`] that is returned by [`MinioClient::upload_part`](crate::s3::client::MinioClient::upload_part).
@@ -419,6 +436,7 @@ pub type UploadPartBldr = UploadPartBuilder<(
     (),
     (Option<String>,),
     (Option<u16>,),
+    (),
     (),
     (),
     (),
@@ -473,6 +491,10 @@ impl ToS3Request for UploadPart {
             headers.add(algorithm.header_name(), checksum_value);
         }
 
+        if let Some(storage_class) = &self.storage_class {
+            headers.add(X_AMZ_STORAGE_CLASS, storage_class);
+        }
+
         let mut query_params: Multimap = self.extra_query_params.unwrap_or_default();
 
         if let Some(upload_id) = self.upload_id {
@@ -516,6 +538,33 @@ pub type PutObjectBldr = PutObjectBuilder<((UploadPart,),)>;
 
 impl S3Api for PutObject {
     type S3Response = PutObjectResponse;
+}
+
+impl PutObject {
+    /// Sets the storage class for the object, sent as the `X-Amz-Storage-Class`
+    /// header (e.g. `STANDARD`, `REDUCED_REDUNDANCY`).
+    ///
+    /// Unlike the other write builders, this is a method on the built
+    /// [`PutObject`] rather than on its builder, so it is called *after*
+    /// `.build()`:
+    ///
+    /// ```no_run
+    /// # use minio::s3::{MinioClient, types::S3Api, segmented_bytes::SegmentedBytes};
+    /// # async fn run(client: MinioClient, data: SegmentedBytes) -> Result<(), Box<dyn std::error::Error>> {
+    /// client
+    ///     .put_object("bucket", "object", data)?
+    ///     .build()
+    ///     .storage_class("REDUCED_REDUNDANCY")
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn storage_class(mut self, storage_class: impl Into<String>) -> Self {
+        self.inner.storage_class = Some(storage_class.into());
+        self
+    }
 }
 
 impl ToS3Request for PutObject {
@@ -607,6 +656,12 @@ pub struct PutObjectContent {
     #[builder(default, setter(into))]
     not_match_etag: Option<String>,
 
+    /// Optional storage class for the object, sent as the `X-Amz-Storage-Class`
+    /// header. Applied to the single-part `PutObject` for small objects and to
+    /// `CreateMultipartUpload` for objects uploaded in multiple parts.
+    #[builder(default, setter(into))]
+    storage_class: Option<String>,
+
     // source data
     #[builder(!default, setter(into))] // force required + accept Into<String>
     input_content: ObjectContent,
@@ -629,6 +684,7 @@ pub type PutObjectContentBldr = PutObjectContentBuilder<(
     (),
     (BucketName,),
     (ObjectKey,),
+    (),
     (),
     (),
     (),
@@ -703,6 +759,7 @@ impl PutObjectContent {
                     checksum_algorithm: self.checksum_algorithm,
                     use_trailing_checksum: self.use_trailing_checksum,
                     use_signed_streaming: self.use_signed_streaming,
+                    storage_class: self.storage_class.clone(),
                 })
                 .build()
                 .send()
@@ -731,6 +788,7 @@ impl PutObjectContent {
                 .legal_hold(self.legal_hold)
                 .content_type(self.content_type.clone())
                 .checksum_algorithm(self.checksum_algorithm)
+                .storage_class(self.storage_class.clone())
                 .build()
                 .send()
                 .await?;
@@ -831,6 +889,7 @@ impl PutObjectContent {
                 checksum_algorithm: self.checksum_algorithm,
                 use_trailing_checksum: self.use_trailing_checksum,
                 use_signed_streaming: self.use_signed_streaming,
+                storage_class: None,
             }
             .send()
             .await?;
@@ -1123,6 +1182,57 @@ mod tests {
         let mut headers = Multimap::new();
         add_conditional_etag_headers(&mut headers, &Some("*".to_string()), &None);
         assert_eq!(headers.get(IF_MATCH).map(String::as_str), Some("*"));
+    }
+
+    fn test_client() -> MinioClient {
+        use crate::s3::creds::StaticProvider;
+        use crate::s3::http::BaseUrl;
+        let base_url = "http://localhost:9000/".parse::<BaseUrl>().unwrap();
+        let provider = StaticProvider::new("minioadmin", "minioadmin", None);
+        MinioClient::new(base_url, Some(provider), None, None).unwrap()
+    }
+
+    #[test]
+    fn put_object_emits_storage_class_header() {
+        let data = SegmentedBytes::from(Bytes::from_static(b"hello"));
+        let req = test_client()
+            .put_object("test-bucket", "test-object", data)
+            .unwrap()
+            .build()
+            .storage_class("REDUCED_REDUNDANCY")
+            .to_s3request()
+            .unwrap();
+        assert_eq!(
+            req.headers.get(X_AMZ_STORAGE_CLASS).map(String::as_str),
+            Some("REDUCED_REDUNDANCY")
+        );
+    }
+
+    #[test]
+    fn put_object_omits_storage_class_by_default() {
+        let data = SegmentedBytes::from(Bytes::from_static(b"hello"));
+        let req = test_client()
+            .put_object("test-bucket", "test-object", data)
+            .unwrap()
+            .build()
+            .to_s3request()
+            .unwrap();
+        assert!(req.headers.get(X_AMZ_STORAGE_CLASS).is_none());
+    }
+
+    #[test]
+    fn create_multipart_upload_emits_storage_class_header() {
+        let req = test_client()
+            .create_multipart_upload("test-bucket", "test-object")
+            .unwrap()
+            .storage_class(Some("GLACIER".to_string()))
+            .build()
+            .to_s3request()
+            .unwrap();
+        assert_eq!(
+            req.headers.get(X_AMZ_STORAGE_CLASS).map(String::as_str),
+            Some("GLACIER")
+        );
     }
 
     /// Objects small enough to fit in MAX_MULTIPART_COUNT parts at DEFAULT_PART_SIZE

--- a/src/s3/builders/stat_object.rs
+++ b/src/s3/builders/stat_object.rs
@@ -21,7 +21,6 @@ use crate::s3::response::StatObjectResponse;
 use crate::s3::sse::{Sse, SseCustomerKey};
 use crate::s3::types::{BucketName, ObjectKey, Region, S3Api, S3Request, ToS3Request, VersionId};
 use crate::s3::utils::{UtcTime, check_ssec, to_http_header_value};
-use async_trait::async_trait;
 use http::Method;
 use typed_builder::TypedBuilder;
 
@@ -64,6 +63,13 @@ pub struct StatObject {
     modified_since: Option<UtcTime>,
     #[builder(default, setter(into))]
     unmodified_since: Option<UtcTime>,
+
+    /// When true, requests the server to return the object's stored checksum by
+    /// sending `x-amz-checksum-mode: ENABLED`. For multipart objects the value
+    /// is the checksum of part checksums. The checksum is exposed on the
+    /// response via [`HasChecksumHeaders`](crate::s3::response_traits::HasChecksumHeaders).
+    #[builder(default = false)]
+    enable_checksum: bool,
 }
 
 /// Builder type for [`StatObject`] that is returned by [`MinioClient::stat_object`](crate::s3::client::MinioClient::stat_object).
@@ -82,13 +88,13 @@ pub type StatObjectBldr = StatObjectBuilder<(
     (),
     (),
     (),
+    (),
 )>;
 
 impl S3Api for StatObject {
     type S3Response = StatObjectResponse;
 }
 
-#[async_trait]
 impl ToS3Request for StatObject {
     fn to_s3request(self) -> Result<S3Request, ValidationErr> {
         check_ssec(&self.ssec, &self.client)?;
@@ -110,6 +116,9 @@ impl ToS3Request for StatObject {
             if let Some(v) = self.ssec {
                 headers.add_multimap(v.headers());
             }
+            if self.enable_checksum {
+                headers.add(X_AMZ_CHECKSUM_MODE, "ENABLED");
+            }
         }
 
         let mut query_params: Multimap = self.extra_query_params.unwrap_or_default();
@@ -124,5 +133,44 @@ impl ToS3Request for StatObject {
             .query_params(query_params)
             .headers(headers)
             .build())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::s3::creds::StaticProvider;
+    use crate::s3::http::BaseUrl;
+
+    fn test_client() -> MinioClient {
+        let base_url = "http://localhost:9000/".parse::<BaseUrl>().unwrap();
+        let provider = StaticProvider::new("minioadmin", "minioadmin", None);
+        MinioClient::new(base_url, Some(provider), None, None).unwrap()
+    }
+
+    #[test]
+    fn enable_checksum_emits_header() {
+        let req = test_client()
+            .stat_object("test-bucket", "test-object")
+            .unwrap()
+            .enable_checksum(true)
+            .build()
+            .to_s3request()
+            .unwrap();
+        assert_eq!(
+            req.headers.get(X_AMZ_CHECKSUM_MODE).map(String::as_str),
+            Some("ENABLED")
+        );
+    }
+
+    #[test]
+    fn checksum_header_absent_by_default() {
+        let req = test_client()
+            .stat_object("test-bucket", "test-object")
+            .unwrap()
+            .build()
+            .to_s3request()
+            .unwrap();
+        assert!(req.headers.get(X_AMZ_CHECKSUM_MODE).is_none());
     }
 }

--- a/src/s3/client/mod.rs
+++ b/src/s3/client/mod.rs
@@ -485,13 +485,13 @@ impl MinioClient {
     /// exchange it requires (for example STS or EC2/ECS metadata) and
     /// refreshing its cached credentials.
     ///
-    /// Network-backed providers such as [`LdapIdentityProvider`](crate::s3::creds::LdapIdentityProvider),
-    /// [`WebIdentityProvider`](crate::s3::creds::WebIdentityProvider),
-    /// [`IamRoleProvider`](crate::s3::creds::IamRoleProvider), and
-    /// [`ChainProvider`](crate::s3::creds::ChainProvider) return empty
-    /// credentials from the synchronous signing path until they are primed;
-    /// call this once before issuing requests (and again to force a refresh).
-    /// It is a no-op for synchronous providers such as
+    /// The request and presign paths already prime the provider automatically
+    /// before signing, so calling this is optional. Use it to pre-warm a
+    /// network-backed provider (such as
+    /// [`IamRoleProvider`](crate::s3::creds::IamRoleProvider) or
+    /// [`ChainProvider`](crate::s3::creds::ChainProvider)) before the first
+    /// request, or to surface a credential-fetch error eagerly. It is a no-op
+    /// for synchronous providers such as
     /// [`StaticProvider`](crate::s3::creds::StaticProvider).
     pub async fn ensure_credentials(&self) -> Result<(), Error> {
         if let Some(provider) = &self.shared.provider {
@@ -787,7 +787,7 @@ impl MinioClient {
             "s3"
         };
         let chunk_signing_context = if let Some(p) = &self.shared.provider {
-            let creds = p.fetch();
+            let creds = p.ensure_credentials().await?;
             if creds.session_token.is_some() {
                 headers.add(X_AMZ_SECURITY_TOKEN, creds.session_token.unwrap());
             }
@@ -1036,7 +1036,7 @@ impl MinioClient {
             let date = utc_now();
             headers.add(X_AMZ_DATE, to_amz_date(date));
             if let Some(p) = &self.shared.provider {
-                let creds = p.fetch();
+                let creds = p.ensure_credentials().await?;
                 if let Some(token) = &creds.session_token {
                     headers.add(X_AMZ_SECURITY_TOKEN, token);
                 }
@@ -1254,7 +1254,7 @@ impl MinioClient {
 
         // Sign the request if we have credentials
         if let Some(provider) = &self.shared.provider {
-            let creds = provider.fetch();
+            let creds = provider.ensure_credentials().await?;
             if let Some(token) = &creds.session_token {
                 headers.add(X_AMZ_SECURITY_TOKEN, token);
             }
@@ -1519,5 +1519,58 @@ mod tests {
         );
         let root = Element::parse(body.clone().reader()).unwrap();
         assert_ne!(root.name, "Error");
+    }
+
+    use crate::s3::creds::{Credentials, Provider, StaticProvider};
+    use crate::s3::error::ValidationErr;
+    use crate::s3::http::BaseUrl;
+
+    #[derive(Debug)]
+    struct FakeProvider {
+        fail: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl Provider for FakeProvider {
+        fn fetch(&self) -> Credentials {
+            Credentials::empty()
+        }
+        async fn ensure_credentials(&self) -> Result<Credentials, ValidationErr> {
+            if self.fail {
+                Err(ValidationErr::StrError {
+                    message: "provider unavailable".into(),
+                    source: None,
+                })
+            } else {
+                Ok(Credentials {
+                    access_key: "AK".into(),
+                    secret_key: "SK".into(),
+                    session_token: None,
+                })
+            }
+        }
+    }
+
+    fn client_with<P: Provider + Send + Sync + 'static>(provider: Option<P>) -> MinioClient {
+        let base_url = "http://localhost:9000/".parse::<BaseUrl>().unwrap();
+        MinioClient::new(base_url, provider, None, None).unwrap()
+    }
+
+    #[tokio::test]
+    async fn ensure_credentials_primes_present_provider() {
+        let client = client_with(Some(FakeProvider { fail: false }));
+        assert!(client.ensure_credentials().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn ensure_credentials_is_noop_without_provider() {
+        let client = client_with(None::<StaticProvider>);
+        assert!(client.ensure_credentials().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn ensure_credentials_propagates_provider_error() {
+        let client = client_with(Some(FakeProvider { fail: true }));
+        assert!(client.ensure_credentials().await.is_err());
     }
 }

--- a/src/s3/client/mod.rs
+++ b/src/s3/client/mod.rs
@@ -481,6 +481,25 @@ impl MinioClient {
             .build()
     }
 
+    /// Primes the configured credential provider, performing any network
+    /// exchange it requires (for example STS or EC2/ECS metadata) and
+    /// refreshing its cached credentials.
+    ///
+    /// Network-backed providers such as [`LdapIdentityProvider`](crate::s3::creds::LdapIdentityProvider),
+    /// [`WebIdentityProvider`](crate::s3::creds::WebIdentityProvider),
+    /// [`IamRoleProvider`](crate::s3::creds::IamRoleProvider), and
+    /// [`ChainProvider`](crate::s3::creds::ChainProvider) return empty
+    /// credentials from the synchronous signing path until they are primed;
+    /// call this once before issuing requests (and again to force a refresh).
+    /// It is a no-op for synchronous providers such as
+    /// [`StaticProvider`](crate::s3::creds::StaticProvider).
+    pub async fn ensure_credentials(&self) -> Result<(), Error> {
+        if let Some(provider) = &self.shared.provider {
+            provider.ensure_credentials().await?;
+        }
+        Ok(())
+    }
+
     /// Returns whether this client uses an AWS host.
     pub fn is_aws_host(&self) -> bool {
         self.shared.base_url.is_aws_host()

--- a/src/s3/creds.rs
+++ b/src/s3/creds.rs
@@ -479,6 +479,23 @@ mod tests {
     }
 
     #[test]
+    fn parse_response_missing_session_token_errors() {
+        let xml = r#"<AssumeRoleWithLDAPIdentityResponse>
+  <AssumeRoleWithLDAPIdentityResult>
+    <Credentials>
+      <AccessKeyId>AKIATEST</AccessKeyId>
+      <SecretAccessKey>SECRETTEST</SecretAccessKey>
+      <Expiration>2030-01-01T00:00:00Z</Expiration>
+    </Credentials>
+  </AssumeRoleWithLDAPIdentityResult>
+</AssumeRoleWithLDAPIdentityResponse>"#;
+        assert!(matches!(
+            parse_ldap_identity_response(xml),
+            Err(ValidationErr::XmlError { .. })
+        ));
+    }
+
+    #[test]
     fn fetch_returns_empty_before_priming() {
         let provider = LdapIdentityProvider::new("http://localhost:9000", "u", "p");
         let creds = provider.fetch();

--- a/src/s3/creds.rs
+++ b/src/s3/creds.rs
@@ -31,6 +31,8 @@ mod web_identity;
 
 #[cfg(test)]
 pub(crate) mod mock_http;
+#[cfg(test)]
+pub(crate) mod test_support;
 
 pub use assume_role::AssumeRoleProvider;
 pub use chain::ChainProvider;
@@ -329,7 +331,11 @@ pub(crate) fn parse_sts_credentials(
         text("AccessKeyId").ok_or_else(|| xml_error("missing AccessKeyId in STS response"))?;
     let secret_key = text("SecretAccessKey")
         .ok_or_else(|| xml_error("missing SecretAccessKey in STS response"))?;
-    let session_token = text("SessionToken");
+    // STS temporary credentials always carry a session token; treat its absence
+    // as a malformed response rather than caching unusable credentials.
+    let session_token = Some(
+        text("SessionToken").ok_or_else(|| xml_error("missing SessionToken in STS response"))?,
+    );
     let expiration = match text("Expiration") {
         Some(value) => from_iso8601utc(&value)?,
         None => now + Duration::hours(1),

--- a/src/s3/creds.rs
+++ b/src/s3/creds.rs
@@ -17,12 +17,30 @@
 
 use crate::s3::error::ValidationErr;
 use crate::s3::utils::{UtcTime, from_iso8601utc, utc_now};
+use async_trait::async_trait;
 use chrono::Duration;
 use std::sync::RwLock;
 use xmltree::Element;
 
+mod assume_role;
+mod chain;
+mod env;
+mod file;
+mod iam;
+mod web_identity;
+
+#[cfg(test)]
+pub(crate) mod mock_http;
+
+pub use assume_role::AssumeRoleProvider;
+pub use chain::ChainProvider;
+pub use env::EnvProvider;
+pub use file::FileProvider;
+pub use iam::IamRoleProvider;
+pub use web_identity::WebIdentityProvider;
+
 /// STS API version used by the MinIO Security Token Service.
-const STS_VERSION: &str = "2011-06-15";
+pub(crate) const STS_VERSION: &str = "2011-06-15";
 
 /// Fraction of a credential's lifetime that must elapse before it is
 /// refreshed, mirroring Go's `defaultExpiryWindow` of 0.8 (refresh once 80% of
@@ -30,16 +48,63 @@ const STS_VERSION: &str = "2011-06-15";
 const DEFAULT_EXPIRY_WINDOW_RATIO: f64 = 0.8;
 
 /// Credentials containing access key, secret key, and optional session token.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Credentials {
     pub access_key: String,
     pub secret_key: String,
     pub session_token: Option<String>,
 }
 
+impl std::fmt::Debug for Credentials {
+    /// Redacts the secret key and session token so credentials are never
+    /// emitted in plaintext through `Debug` (logs, panics, error chains).
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Credentials")
+            .field("access_key", &self.access_key)
+            .field("secret_key", &"<redacted>")
+            .field(
+                "session_token",
+                &self.session_token.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
+}
+
+impl Credentials {
+    /// Returns credentials with empty access and secret keys, used by
+    /// network-backed providers before they have been primed.
+    pub(crate) fn empty() -> Self {
+        Credentials {
+            access_key: String::new(),
+            secret_key: String::new(),
+            session_token: None,
+        }
+    }
+
+    /// Returns true when no usable access/secret key pair is present.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.access_key.is_empty() || self.secret_key.is_empty()
+    }
+}
+
 /// Provider trait to fetch credentials.
-pub trait Provider: std::fmt::Debug {
+///
+/// [`fetch`](Provider::fetch) is synchronous and infallible: network-backed
+/// providers return their cached credentials and may yield
+/// [`Credentials::empty`] until primed. [`ensure_credentials`](Provider::ensure_credentials)
+/// performs any network exchange (refreshing the cache) and is what
+/// [`ChainProvider`] awaits to select a working provider before signing.
+#[async_trait]
+pub trait Provider: std::fmt::Debug + Send + Sync {
+    /// Returns the currently available credentials without performing any I/O.
     fn fetch(&self) -> Credentials;
+
+    /// Ensures credentials are available, performing any required network
+    /// exchange or refresh, and returns them. The default implementation
+    /// returns [`Provider::fetch`] for synchronous providers.
+    async fn ensure_credentials(&self) -> Result<Credentials, ValidationErr> {
+        Ok(self.fetch())
+    }
 }
 
 /// Static credential provider.
@@ -68,6 +133,7 @@ impl StaticProvider {
     }
 }
 
+#[async_trait]
 impl Provider for StaticProvider {
     fn fetch(&self) -> Credentials {
         self.creds.clone()
@@ -93,7 +159,6 @@ fn validate_config_name(name: &str) -> Result<(), ValidationErr> {
 /// infallible, the network exchange happens in [`LdapIdentityProvider::refresh`]
 /// (async) and must be primed before the provider is used for signing; see
 /// [`LdapIdentityProvider::fetch_credentials`].
-#[derive(Debug)]
 pub struct LdapIdentityProvider {
     sts_endpoint: String,
     ldap_username: String,
@@ -104,10 +169,25 @@ pub struct LdapIdentityProvider {
     cache: RwLock<Option<CachedCredentials>>,
 }
 
+impl std::fmt::Debug for LdapIdentityProvider {
+    /// Redacts the LDAP password so it is never emitted in plaintext.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LdapIdentityProvider")
+            .field("sts_endpoint", &self.sts_endpoint)
+            .field("ldap_username", &self.ldap_username)
+            .field("ldap_password", &"<redacted>")
+            .field("policy", &self.policy)
+            .field("duration_seconds", &self.duration_seconds)
+            .field("config_name", &self.config_name)
+            .field("cache", &self.cache)
+            .finish()
+    }
+}
+
 #[derive(Clone, Debug)]
-struct CachedCredentials {
-    creds: Credentials,
-    refresh_after: UtcTime,
+pub(crate) struct CachedCredentials {
+    pub(crate) creds: Credentials,
+    pub(crate) refresh_after: UtcTime,
 }
 
 impl LdapIdentityProvider {
@@ -217,18 +297,24 @@ impl LdapIdentityProvider {
     }
 }
 
-fn xml_error(message: &str) -> ValidationErr {
+pub(crate) fn xml_error(message: &str) -> ValidationErr {
     ValidationErr::XmlError {
         message: message.to_string(),
         source: None,
     }
 }
 
-fn parse_ldap_identity_response(xml: &str) -> Result<CachedCredentials, ValidationErr> {
+/// Parses a `Credentials` element nested under `result_element` from an STS XML
+/// response (`AssumeRole*` actions share this layout) into cached credentials
+/// with a computed refresh deadline.
+pub(crate) fn parse_sts_credentials(
+    xml: &str,
+    result_element: &str,
+) -> Result<CachedCredentials, ValidationErr> {
     let now = utc_now();
     let root = Element::parse(xml.as_bytes())?;
     let credentials = root
-        .get_child("AssumeRoleWithLDAPIdentityResult")
+        .get_child(result_element)
         .and_then(|result| result.get_child("Credentials"))
         .ok_or_else(|| xml_error("missing Credentials in STS response"))?;
 
@@ -259,9 +345,13 @@ fn parse_ldap_identity_response(xml: &str) -> Result<CachedCredentials, Validati
     })
 }
 
+fn parse_ldap_identity_response(xml: &str) -> Result<CachedCredentials, ValidationErr> {
+    parse_sts_credentials(xml, "AssumeRoleWithLDAPIdentityResult")
+}
+
 /// Computes the instant after which credentials should be refreshed, applying
 /// the expiry-window ratio to the time remaining until `expiration`.
-fn refresh_deadline(now: UtcTime, expiration: UtcTime) -> UtcTime {
+pub(crate) fn refresh_deadline(now: UtcTime, expiration: UtcTime) -> UtcTime {
     let remaining = expiration - now;
     if remaining <= Duration::zero() {
         return expiration;
@@ -270,6 +360,7 @@ fn refresh_deadline(now: UtcTime, expiration: UtcTime) -> UtcTime {
     now + Duration::milliseconds(elapsed_before_refresh as i64)
 }
 
+#[async_trait]
 impl Provider for LdapIdentityProvider {
     fn fetch(&self) -> Credentials {
         self.cache
@@ -277,11 +368,11 @@ impl Provider for LdapIdentityProvider {
             .unwrap()
             .as_ref()
             .map(|cached| cached.creds.clone())
-            .unwrap_or_else(|| Credentials {
-                access_key: String::new(),
-                secret_key: String::new(),
-                session_token: None,
-            })
+            .unwrap_or_else(Credentials::empty)
+    }
+
+    async fn ensure_credentials(&self) -> Result<Credentials, ValidationErr> {
+        self.fetch_credentials().await
     }
 }
 
@@ -388,6 +479,22 @@ mod tests {
         assert!(creds.access_key.is_empty());
         assert!(creds.secret_key.is_empty());
         assert!(creds.session_token.is_none());
+    }
+
+    #[test]
+    fn debug_redacts_secrets() {
+        let creds = Credentials {
+            access_key: "AKIATEST".to_string(),
+            secret_key: "SUPERSECRET".to_string(),
+            session_token: Some("SECRETTOKEN".to_string()),
+        };
+        let rendered = format!("{creds:?}");
+        assert!(rendered.contains("AKIATEST"));
+        assert!(!rendered.contains("SUPERSECRET"));
+        assert!(!rendered.contains("SECRETTOKEN"));
+
+        let provider = LdapIdentityProvider::new("http://localhost:9000", "alice", "ldap-pass");
+        assert!(!format!("{provider:?}").contains("ldap-pass"));
     }
 
     #[test]

--- a/src/s3/creds/assume_role.rs
+++ b/src/s3/creds/assume_role.rs
@@ -1,0 +1,350 @@
+// MinIO Rust Library for Amazon S3 Compatible Cloud Storage
+// Copyright 2025 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! STS `AssumeRole` credential provider.
+
+use crate::s3::creds::{
+    CachedCredentials, Credentials, Provider, STS_VERSION, parse_sts_credentials, xml_error,
+};
+use crate::s3::error::ValidationErr;
+use crate::s3::header_constants::{CONTENT_TYPE, HOST, X_AMZ_CONTENT_SHA256, X_AMZ_DATE};
+use crate::s3::multimap_ext::{Multimap, MultimapExt};
+use crate::s3::signer::{SigningKeyCache, sign_v4_with_service_type};
+use crate::s3::types::Region;
+use crate::s3::utils::{sha256_hash, to_amz_date, utc_now};
+use async_trait::async_trait;
+use http::Method;
+use std::sync::RwLock;
+use std::time::Duration as StdDuration;
+
+const REQUEST_TIMEOUT: StdDuration = StdDuration::from_secs(60);
+const DEFAULT_SESSION_NAME: &str = "minio-rs-assume-role";
+const STS_SERVICE: &str = "sts";
+
+/// Credential provider that obtains temporary credentials from an STS endpoint
+/// via the [`AssumeRole`](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)
+/// action. The STS request is signed with AWS Signature V4 using the supplied
+/// long-term access and secret keys.
+///
+/// Like other network-backed providers, [`Provider::fetch`] returns cached
+/// credentials; call [`Provider::ensure_credentials`] (awaited) to perform the
+/// exchange and prime the cache.
+pub struct AssumeRoleProvider {
+    sts_endpoint: String,
+    access_key: String,
+    secret_key: String,
+    region: Region,
+    role_arn: Option<String>,
+    role_session_name: Option<String>,
+    duration_seconds: Option<u32>,
+    policy: Option<String>,
+    external_id: Option<String>,
+    signing_key_cache: RwLock<SigningKeyCache>,
+    cache: RwLock<Option<CachedCredentials>>,
+}
+
+impl std::fmt::Debug for AssumeRoleProvider {
+    /// Redacts the secret key so it is never emitted in plaintext.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AssumeRoleProvider")
+            .field("sts_endpoint", &self.sts_endpoint)
+            .field("access_key", &self.access_key)
+            .field("secret_key", &"<redacted>")
+            .field("region", &self.region)
+            .field("role_arn", &self.role_arn)
+            .field("role_session_name", &self.role_session_name)
+            .field("duration_seconds", &self.duration_seconds)
+            .field("policy", &self.policy)
+            .field("external_id", &self.external_id)
+            .field("cache", &self.cache)
+            .finish()
+    }
+}
+
+impl AssumeRoleProvider {
+    /// Returns a new provider targeting `sts_endpoint`, signing the request with
+    /// the given long-term `access_key`/`secret_key`.
+    pub fn new(
+        sts_endpoint: impl Into<String>,
+        access_key: impl Into<String>,
+        secret_key: impl Into<String>,
+    ) -> Result<Self, ValidationErr> {
+        Ok(AssumeRoleProvider {
+            sts_endpoint: sts_endpoint.into(),
+            access_key: access_key.into(),
+            secret_key: secret_key.into(),
+            region: Region::new("us-east-1")?,
+            role_arn: None,
+            role_session_name: None,
+            duration_seconds: None,
+            policy: None,
+            external_id: None,
+            signing_key_cache: RwLock::new(SigningKeyCache::new()),
+            cache: RwLock::new(None),
+        })
+    }
+
+    /// Sets the region used for the SigV4 signing scope (default `us-east-1`).
+    pub fn region(mut self, region: Region) -> Self {
+        self.region = region;
+        self
+    }
+
+    /// Sets the role ARN to assume (`RoleArn`).
+    pub fn role_arn(mut self, role_arn: impl Into<String>) -> Self {
+        self.role_arn = Some(role_arn.into());
+        self
+    }
+
+    /// Sets the role session name (`RoleSessionName`).
+    pub fn role_session_name(mut self, name: impl Into<String>) -> Self {
+        self.role_session_name = Some(name.into());
+        self
+    }
+
+    /// Sets the requested credential lifetime in seconds (`DurationSeconds`).
+    pub fn duration_seconds(mut self, seconds: u32) -> Self {
+        self.duration_seconds = Some(seconds);
+        self
+    }
+
+    /// Sets the session policy applied to the generated credentials.
+    pub fn policy(mut self, policy: impl Into<String>) -> Self {
+        self.policy = Some(policy.into());
+        self
+    }
+
+    /// Sets the external ID (`ExternalId`).
+    pub fn external_id(mut self, external_id: impl Into<String>) -> Self {
+        self.external_id = Some(external_id.into());
+        self
+    }
+
+    /// Builds the form-urlencoded STS request body for the configured options.
+    fn build_request_body(&self) -> String {
+        let session_name = self
+            .role_session_name
+            .clone()
+            .unwrap_or_else(|| DEFAULT_SESSION_NAME.to_string());
+        let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+        serializer
+            .append_pair("Action", "AssumeRole")
+            .append_pair("Version", STS_VERSION)
+            .append_pair("RoleSessionName", &session_name);
+        if let Some(role_arn) = &self.role_arn {
+            serializer.append_pair("RoleArn", role_arn);
+        }
+        if let Some(duration) = self.duration_seconds {
+            serializer.append_pair("DurationSeconds", &duration.to_string());
+        }
+        if let Some(policy) = &self.policy {
+            serializer.append_pair("Policy", policy);
+        }
+        if let Some(external_id) = &self.external_id {
+            serializer.append_pair("ExternalId", external_id);
+        }
+        serializer.finish()
+    }
+
+    /// Performs the signed STS exchange and stores the result in the cache.
+    pub async fn refresh(&self) -> Result<Credentials, ValidationErr> {
+        let body = self.build_request_body();
+        let url = reqwest::Url::parse(&self.sts_endpoint)
+            .map_err(|e| xml_error(&format!("invalid STS endpoint: {e}")))?;
+
+        let host = match url.port() {
+            Some(port) => format!(
+                "{}:{port}",
+                url.host_str()
+                    .ok_or_else(|| xml_error("STS endpoint has no host"))?
+            ),
+            None => url
+                .host_str()
+                .ok_or_else(|| xml_error("STS endpoint has no host"))?
+                .to_string(),
+        };
+        let path = url.path();
+        let content_sha256 = sha256_hash(body.as_bytes());
+        let date = utc_now();
+
+        let mut headers = Multimap::new();
+        headers.add(HOST, host);
+        headers.add(CONTENT_TYPE, "application/x-www-form-urlencoded");
+        headers.add(X_AMZ_DATE, to_amz_date(date));
+        headers.add(X_AMZ_CONTENT_SHA256, content_sha256.clone());
+
+        let query_params = Multimap::new();
+        sign_v4_with_service_type(
+            &self.signing_key_cache,
+            STS_SERVICE,
+            &Method::POST,
+            path,
+            &self.region,
+            &mut headers,
+            &query_params,
+            &self.access_key,
+            &self.secret_key,
+            &content_sha256,
+            date,
+        );
+
+        let mut request = reqwest::Client::new()
+            .post(url.clone())
+            .timeout(REQUEST_TIMEOUT)
+            .body(body);
+        for (key, values) in headers.iter_all() {
+            for value in values {
+                request = request.header(key, value);
+            }
+        }
+
+        let response = request.send().await.map_err(ValidationErr::from)?;
+        let status = response.status();
+        let text = response.text().await?;
+        if !status.is_success() {
+            return Err(xml_error(&format!(
+                "STS AssumeRole failed with status {status}: {text}"
+            )));
+        }
+
+        let cached = parse_sts_credentials(&text, "AssumeRoleResult")?;
+        let creds = cached.creds.clone();
+        *self.cache.write().unwrap() = Some(cached);
+        Ok(creds)
+    }
+}
+
+#[async_trait]
+impl Provider for AssumeRoleProvider {
+    fn fetch(&self) -> Credentials {
+        self.cache
+            .read()
+            .unwrap()
+            .as_ref()
+            .map(|cached| cached.creds.clone())
+            .unwrap_or_else(Credentials::empty)
+    }
+
+    async fn ensure_credentials(&self) -> Result<Credentials, ValidationErr> {
+        if let Some(cached) = self.cache.read().unwrap().as_ref()
+            && utc_now() < cached.refresh_after
+        {
+            return Ok(cached.creds.clone());
+        }
+        self.refresh().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn parse_body(body: &str) -> HashMap<String, String> {
+        url::form_urlencoded::parse(body.as_bytes())
+            .into_owned()
+            .collect()
+    }
+
+    #[test]
+    fn build_request_body_minimal() {
+        let provider = AssumeRoleProvider::new("http://localhost:9000", "ak", "sk").unwrap();
+        let params = parse_body(&provider.build_request_body());
+        assert_eq!(params["Action"], "AssumeRole");
+        assert_eq!(params["Version"], "2011-06-15");
+        assert_eq!(params["RoleSessionName"], DEFAULT_SESSION_NAME);
+        assert!(!params.contains_key("RoleArn"));
+        assert!(!params.contains_key("DurationSeconds"));
+    }
+
+    #[test]
+    fn build_request_body_with_options() {
+        let provider = AssumeRoleProvider::new("http://localhost:9000", "ak", "sk")
+            .unwrap()
+            .role_arn("arn:aws:iam::123:role/test")
+            .role_session_name("sess")
+            .duration_seconds(3600)
+            .policy("{}")
+            .external_id("ext-1");
+        let params = parse_body(&provider.build_request_body());
+        assert_eq!(params["RoleArn"], "arn:aws:iam::123:role/test");
+        assert_eq!(params["RoleSessionName"], "sess");
+        assert_eq!(params["DurationSeconds"], "3600");
+        assert_eq!(params["Policy"], "{}");
+        assert_eq!(params["ExternalId"], "ext-1");
+    }
+
+    #[test]
+    fn parses_assume_role_response() {
+        let xml = r#"<?xml version="1.0"?>
+<AssumeRoleResponse>
+  <AssumeRoleResult>
+    <Credentials>
+      <AccessKeyId>AKID</AccessKeyId>
+      <SecretAccessKey>SECRET</SecretAccessKey>
+      <SessionToken>TOKEN</SessionToken>
+      <Expiration>2030-01-01T00:00:00Z</Expiration>
+    </Credentials>
+  </AssumeRoleResult>
+</AssumeRoleResponse>"#;
+        let cached = parse_sts_credentials(xml, "AssumeRoleResult").unwrap();
+        assert_eq!(cached.creds.access_key, "AKID");
+        assert_eq!(cached.creds.secret_key, "SECRET");
+        assert_eq!(cached.creds.session_token.as_deref(), Some("TOKEN"));
+    }
+
+    #[test]
+    fn fetch_empty_before_priming() {
+        let provider = AssumeRoleProvider::new("http://localhost:9000", "ak", "sk").unwrap();
+        assert!(provider.fetch().is_empty());
+    }
+
+    #[tokio::test]
+    async fn assume_role_sts_flow_is_signed() {
+        use crate::s3::creds::mock_http::{self, Request, Responder};
+        use std::sync::Arc;
+
+        const STS_XML: &str = r#"<?xml version="1.0"?>
+<AssumeRoleResponse><AssumeRoleResult><Credentials>
+<AccessKeyId>ARAK</AccessKeyId><SecretAccessKey>ARSK</SecretAccessKey>
+<SessionToken>ARTOKEN</SessionToken><Expiration>2030-01-01T00:00:00Z</Expiration>
+</Credentials></AssumeRoleResult></AssumeRoleResponse>"#;
+
+        // Require a SigV4 Authorization header so the test fails if the request
+        // is not signed.
+        let responder: Responder = Arc::new(|req: &Request| {
+            let signed = req
+                .headers
+                .get("authorization")
+                .is_some_and(|v| v.starts_with("AWS4-HMAC-SHA256"));
+            if req.method == "POST" && signed {
+                (200, STS_XML.to_string())
+            } else {
+                (400, "unsigned request".to_string())
+            }
+        });
+        let server = mock_http::start(responder).await;
+
+        let creds = AssumeRoleProvider::new(&server.base_url, "ak", "sk")
+            .unwrap()
+            .role_arn("arn:aws:iam::123456789012:role/test")
+            .refresh()
+            .await
+            .unwrap();
+        assert_eq!(creds.access_key, "ARAK");
+        assert_eq!(creds.secret_key, "ARSK");
+        assert_eq!(creds.session_token.as_deref(), Some("ARTOKEN"));
+    }
+}

--- a/src/s3/creds/assume_role.rs
+++ b/src/s3/creds/assume_role.rs
@@ -133,7 +133,14 @@ impl AssumeRoleProvider {
     }
 
     /// Builds the form-urlencoded STS request body for the configured options.
-    fn build_request_body(&self) -> String {
+    /// Returns an error when the required `RoleArn` is unset or empty, so a
+    /// configuration mistake fails locally rather than as a remote STS error.
+    fn build_request_body(&self) -> Result<String, ValidationErr> {
+        let role_arn = self
+            .role_arn
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| xml_error("role ARN is required for AssumeRole"))?;
         let session_name = self
             .role_session_name
             .clone()
@@ -142,10 +149,8 @@ impl AssumeRoleProvider {
         serializer
             .append_pair("Action", "AssumeRole")
             .append_pair("Version", STS_VERSION)
-            .append_pair("RoleSessionName", &session_name);
-        if let Some(role_arn) = &self.role_arn {
-            serializer.append_pair("RoleArn", role_arn);
-        }
+            .append_pair("RoleSessionName", &session_name)
+            .append_pair("RoleArn", role_arn);
         if let Some(duration) = self.duration_seconds {
             serializer.append_pair("DurationSeconds", &duration.to_string());
         }
@@ -155,12 +160,12 @@ impl AssumeRoleProvider {
         if let Some(external_id) = &self.external_id {
             serializer.append_pair("ExternalId", external_id);
         }
-        serializer.finish()
+        Ok(serializer.finish())
     }
 
     /// Performs the signed STS exchange and stores the result in the cache.
     pub async fn refresh(&self) -> Result<Credentials, ValidationErr> {
-        let body = self.build_request_body();
+        let body = self.build_request_body()?;
         let url = reqwest::Url::parse(&self.sts_endpoint)
             .map_err(|e| xml_error(&format!("invalid STS endpoint: {e}")))?;
 
@@ -260,12 +265,14 @@ mod tests {
 
     #[test]
     fn build_request_body_minimal() {
-        let provider = AssumeRoleProvider::new("http://localhost:9000", "ak", "sk").unwrap();
-        let params = parse_body(&provider.build_request_body());
+        let provider = AssumeRoleProvider::new("http://localhost:9000", "ak", "sk")
+            .unwrap()
+            .role_arn("arn:aws:iam::123:role/test");
+        let params = parse_body(&provider.build_request_body().unwrap());
         assert_eq!(params["Action"], "AssumeRole");
         assert_eq!(params["Version"], "2011-06-15");
         assert_eq!(params["RoleSessionName"], DEFAULT_SESSION_NAME);
-        assert!(!params.contains_key("RoleArn"));
+        assert_eq!(params["RoleArn"], "arn:aws:iam::123:role/test");
         assert!(!params.contains_key("DurationSeconds"));
     }
 
@@ -278,12 +285,23 @@ mod tests {
             .duration_seconds(3600)
             .policy("{}")
             .external_id("ext-1");
-        let params = parse_body(&provider.build_request_body());
+        let params = parse_body(&provider.build_request_body().unwrap());
         assert_eq!(params["RoleArn"], "arn:aws:iam::123:role/test");
         assert_eq!(params["RoleSessionName"], "sess");
         assert_eq!(params["DurationSeconds"], "3600");
         assert_eq!(params["Policy"], "{}");
         assert_eq!(params["ExternalId"], "ext-1");
+    }
+
+    #[test]
+    fn build_request_body_requires_role_arn() {
+        let provider = AssumeRoleProvider::new("http://localhost:9000", "ak", "sk").unwrap();
+        assert!(provider.build_request_body().is_err());
+
+        let empty = AssumeRoleProvider::new("http://localhost:9000", "ak", "sk")
+            .unwrap()
+            .role_arn("");
+        assert!(empty.build_request_body().is_err());
     }
 
     #[test]

--- a/src/s3/creds/chain.rs
+++ b/src/s3/creds/chain.rs
@@ -1,0 +1,186 @@
+// MinIO Rust Library for Amazon S3 Compatible Cloud Storage
+// Copyright 2025 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Chained credential provider.
+
+use crate::s3::creds::{Credentials, EnvProvider, FileProvider, IamRoleProvider, Provider};
+use crate::s3::error::ValidationErr;
+use async_trait::async_trait;
+use std::sync::{Arc, RwLock};
+
+/// Credential provider that tries an ordered list of sub-providers and uses the
+/// first one that yields usable credentials.
+///
+/// Resolution happens in [`Provider::ensure_credentials`], which awaits each
+/// sub-provider in turn (performing any network exchange) and remembers the
+/// first that succeeds. Subsequent synchronous [`Provider::fetch`] calls return
+/// that provider's cached credentials, falling back to scanning the list if it
+/// has none.
+#[derive(Debug)]
+pub struct ChainProvider {
+    providers: Vec<Arc<dyn Provider>>,
+    active: RwLock<Option<usize>>,
+}
+
+impl ChainProvider {
+    /// Returns a chain over the given ordered list of providers.
+    pub fn new(providers: Vec<Arc<dyn Provider>>) -> Self {
+        ChainProvider {
+            providers,
+            active: RwLock::new(None),
+        }
+    }
+
+    /// Returns the default credential chain: environment variables, then the
+    /// shared AWS credentials file, then the EC2/ECS IAM role endpoint.
+    ///
+    /// Web-identity and `AssumeRole` providers require an explicit STS endpoint
+    /// and role configuration, so add them via [`ChainProvider::new`] when
+    /// needed.
+    pub fn default_chain() -> Self {
+        Self::new(vec![
+            Arc::new(EnvProvider::new()),
+            Arc::new(FileProvider::new()),
+            Arc::new(IamRoleProvider::new()),
+        ])
+    }
+}
+
+impl Default for ChainProvider {
+    fn default() -> Self {
+        Self::default_chain()
+    }
+}
+
+#[async_trait]
+impl Provider for ChainProvider {
+    fn fetch(&self) -> Credentials {
+        if let Some(index) = *self.active.read().unwrap() {
+            let creds = self.providers[index].fetch();
+            if !creds.is_empty() {
+                return creds;
+            }
+        }
+        for provider in &self.providers {
+            let creds = provider.fetch();
+            if !creds.is_empty() {
+                return creds;
+            }
+        }
+        Credentials::empty()
+    }
+
+    async fn ensure_credentials(&self) -> Result<Credentials, ValidationErr> {
+        for (index, provider) in self.providers.iter().enumerate() {
+            match provider.ensure_credentials().await {
+                Ok(creds) if !creds.is_empty() => {
+                    *self.active.write().unwrap() = Some(index);
+                    return Ok(creds);
+                }
+                Ok(_) => {}
+                // A provider failing (e.g. IMDS unreachable off-EC2) is not fatal
+                // to the chain: skip it and try the next, mirroring minio-go's
+                // Chain which discards per-provider errors and falls back to
+                // anonymous credentials when none yield a usable pair.
+                Err(e) => log::debug!("credential provider {index} failed: {e}"),
+            }
+        }
+        Ok(Credentials::empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::s3::creds::StaticProvider;
+
+    /// Provider whose async refresh always fails, used to exercise the chain's
+    /// error-skipping behavior.
+    #[derive(Debug)]
+    struct FailingProvider;
+
+    #[async_trait]
+    impl Provider for FailingProvider {
+        fn fetch(&self) -> Credentials {
+            Credentials::empty()
+        }
+        async fn ensure_credentials(&self) -> Result<Credentials, ValidationErr> {
+            Err(ValidationErr::StrError {
+                message: "provider unavailable".into(),
+                source: None,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn later_success_wins_over_earlier_error() {
+        let chain = ChainProvider::new(vec![
+            Arc::new(FailingProvider),
+            Arc::new(StaticProvider::new("AK", "SK", None)),
+        ]);
+        let creds = chain.ensure_credentials().await.unwrap();
+        assert_eq!(creds.access_key, "AK");
+    }
+
+    #[tokio::test]
+    async fn all_failing_falls_back_to_anonymous() {
+        let chain = ChainProvider::new(vec![Arc::new(FailingProvider), Arc::new(FailingProvider)]);
+        let creds = chain.ensure_credentials().await.unwrap();
+        assert!(creds.is_empty());
+    }
+
+    #[test]
+    fn fetch_rescans_when_active_index_is_stale() {
+        let chain = ChainProvider::new(vec![
+            Arc::new(StaticProvider::new("", "", None)),
+            Arc::new(StaticProvider::new("AK", "SK", None)),
+        ]);
+        // Point active at the empty provider; fetch must rescan and find the next.
+        *chain.active.write().unwrap() = Some(0);
+        assert_eq!(chain.fetch().access_key, "AK");
+    }
+
+    #[tokio::test]
+    async fn selects_first_usable_provider() {
+        let empty = StaticProvider::new("", "", None);
+        let good = StaticProvider::new("AK", "SK", None);
+        let chain = ChainProvider::new(vec![Arc::new(empty), Arc::new(good)]);
+
+        let creds = chain.ensure_credentials().await.unwrap();
+        assert_eq!(creds.access_key, "AK");
+        assert_eq!(creds.secret_key, "SK");
+        // Once selected, fetch returns the same provider's credentials.
+        assert_eq!(chain.fetch().access_key, "AK");
+    }
+
+    #[tokio::test]
+    async fn empty_when_no_provider_has_credentials() {
+        let chain = ChainProvider::new(vec![
+            Arc::new(StaticProvider::new("", "", None)),
+            Arc::new(StaticProvider::new("", "", None)),
+        ]);
+        let creds = chain.ensure_credentials().await.unwrap();
+        assert!(creds.is_empty());
+    }
+
+    #[test]
+    fn fetch_scans_providers_before_priming() {
+        let chain = ChainProvider::new(vec![
+            Arc::new(StaticProvider::new("", "", None)),
+            Arc::new(StaticProvider::new("AK", "SK", None)),
+        ]);
+        assert_eq!(chain.fetch().access_key, "AK");
+    }
+}

--- a/src/s3/creds/env.rs
+++ b/src/s3/creds/env.rs
@@ -1,0 +1,120 @@
+// MinIO Rust Library for Amazon S3 Compatible Cloud Storage
+// Copyright 2025 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Environment-variable credential provider.
+
+use crate::s3::creds::{Credentials, Provider};
+use async_trait::async_trait;
+use std::env;
+
+/// Credential provider that reads credentials from the standard AWS
+/// environment variables.
+///
+/// Looks up `AWS_ACCESS_KEY_ID` (falling back to `AWS_ACCESS_KEY`),
+/// `AWS_SECRET_ACCESS_KEY` (falling back to `AWS_SECRET_KEY`), and the optional
+/// `AWS_SESSION_TOKEN`. The environment is read on every [`Provider::fetch`] so
+/// changes are picked up without reconstructing the provider.
+#[derive(Clone, Debug, Default)]
+pub struct EnvProvider;
+
+impl EnvProvider {
+    /// Returns a new environment credential provider.
+    pub fn new() -> Self {
+        EnvProvider
+    }
+}
+
+fn non_empty(name: &str) -> Option<String> {
+    env::var(name).ok().filter(|v| !v.is_empty())
+}
+
+#[async_trait]
+impl Provider for EnvProvider {
+    fn fetch(&self) -> Credentials {
+        let access_key = non_empty("AWS_ACCESS_KEY_ID")
+            .or_else(|| non_empty("AWS_ACCESS_KEY"))
+            .unwrap_or_default();
+        let secret_key = non_empty("AWS_SECRET_ACCESS_KEY")
+            .or_else(|| non_empty("AWS_SECRET_KEY"))
+            .unwrap_or_default();
+        let session_token = non_empty("AWS_SESSION_TOKEN");
+        Credentials {
+            access_key,
+            secret_key,
+            session_token,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Serializes tests that mutate process-wide environment variables.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn clear_env() {
+        for key in [
+            "AWS_ACCESS_KEY_ID",
+            "AWS_ACCESS_KEY",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SECRET_KEY",
+            "AWS_SESSION_TOKEN",
+        ] {
+            unsafe { env::remove_var(key) };
+        }
+    }
+
+    #[test]
+    fn reads_primary_variables() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_env();
+        unsafe {
+            env::set_var("AWS_ACCESS_KEY_ID", "AKID");
+            env::set_var("AWS_SECRET_ACCESS_KEY", "SECRET");
+            env::set_var("AWS_SESSION_TOKEN", "TOKEN");
+        }
+        let creds = EnvProvider::new().fetch();
+        assert_eq!(creds.access_key, "AKID");
+        assert_eq!(creds.secret_key, "SECRET");
+        assert_eq!(creds.session_token.as_deref(), Some("TOKEN"));
+        clear_env();
+    }
+
+    #[test]
+    fn falls_back_to_legacy_variables() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_env();
+        unsafe {
+            env::set_var("AWS_ACCESS_KEY", "LEGACY_AK");
+            env::set_var("AWS_SECRET_KEY", "LEGACY_SK");
+        }
+        let creds = EnvProvider::new().fetch();
+        assert_eq!(creds.access_key, "LEGACY_AK");
+        assert_eq!(creds.secret_key, "LEGACY_SK");
+        assert!(creds.session_token.is_none());
+        clear_env();
+    }
+
+    #[test]
+    fn empty_when_unset() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_env();
+        let creds = EnvProvider::new().fetch();
+        assert!(creds.is_empty());
+        assert!(creds.session_token.is_none());
+    }
+}

--- a/src/s3/creds/env.rs
+++ b/src/s3/creds/env.rs
@@ -61,10 +61,7 @@ impl Provider for EnvProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    // Serializes tests that mutate process-wide environment variables.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    use crate::s3::creds::test_support::ENV_LOCK;
 
     fn clear_env() {
         for key in [
@@ -80,7 +77,7 @@ mod tests {
 
     #[test]
     fn reads_primary_variables() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.blocking_lock();
         clear_env();
         unsafe {
             env::set_var("AWS_ACCESS_KEY_ID", "AKID");
@@ -96,7 +93,7 @@ mod tests {
 
     #[test]
     fn falls_back_to_legacy_variables() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.blocking_lock();
         clear_env();
         unsafe {
             env::set_var("AWS_ACCESS_KEY", "LEGACY_AK");
@@ -111,7 +108,7 @@ mod tests {
 
     #[test]
     fn empty_when_unset() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK.blocking_lock();
         clear_env();
         let creds = EnvProvider::new().fetch();
         assert!(creds.is_empty());

--- a/src/s3/creds/file.rs
+++ b/src/s3/creds/file.rs
@@ -1,0 +1,226 @@
+// MinIO Rust Library for Amazon S3 Compatible Cloud Storage
+// Copyright 2025 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared AWS credentials file provider.
+
+use crate::s3::creds::{Credentials, Provider};
+use async_trait::async_trait;
+use std::env;
+use std::path::PathBuf;
+use std::sync::RwLock;
+
+/// Credential provider that reads credentials from the shared AWS credentials
+/// file (e.g. `~/.aws/credentials`).
+///
+/// The file location defaults to `AWS_SHARED_CREDENTIALS_FILE` when set,
+/// otherwise `$HOME/.aws/credentials` (`%USERPROFILE%\.aws\credentials` on
+/// Windows). The profile defaults to `AWS_PROFILE` (then `AWS_DEFAULT_PROFILE`),
+/// otherwise `default`. Profile sections are matched as `[name]` or
+/// `[profile name]`. The file is parsed lazily on first [`Provider::fetch`] and
+/// the result is cached.
+#[derive(Debug)]
+pub struct FileProvider {
+    filename: Option<PathBuf>,
+    profile: Option<String>,
+    cache: RwLock<Option<Credentials>>,
+}
+
+impl Default for FileProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FileProvider {
+    /// Returns a provider that resolves the file path and profile from the
+    /// environment using the AWS defaults.
+    pub fn new() -> Self {
+        FileProvider {
+            filename: None,
+            profile: None,
+            cache: RwLock::new(None),
+        }
+    }
+
+    /// Overrides the credentials file path.
+    pub fn filename(mut self, path: impl Into<PathBuf>) -> Self {
+        self.filename = Some(path.into());
+        self
+    }
+
+    /// Overrides the profile name to read.
+    pub fn profile(mut self, profile: impl Into<String>) -> Self {
+        self.profile = Some(profile.into());
+        self
+    }
+
+    fn resolved_filename(&self) -> Option<PathBuf> {
+        if let Some(path) = &self.filename {
+            return Some(path.clone());
+        }
+        if let Ok(path) = env::var("AWS_SHARED_CREDENTIALS_FILE")
+            && !path.is_empty()
+        {
+            return Some(PathBuf::from(path));
+        }
+        let home = env::var("HOME")
+            .ok()
+            .or_else(|| env::var("USERPROFILE").ok())
+            .filter(|v| !v.is_empty())?;
+        Some(PathBuf::from(home).join(".aws").join("credentials"))
+    }
+
+    fn resolved_profile(&self) -> String {
+        if let Some(profile) = &self.profile {
+            return profile.clone();
+        }
+        env::var("AWS_PROFILE")
+            .ok()
+            .filter(|v| !v.is_empty())
+            .or_else(|| {
+                env::var("AWS_DEFAULT_PROFILE")
+                    .ok()
+                    .filter(|v| !v.is_empty())
+            })
+            .unwrap_or_else(|| "default".to_string())
+    }
+
+    fn load(&self) -> Credentials {
+        let Some(path) = self.resolved_filename() else {
+            return Credentials::empty();
+        };
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            return Credentials::empty();
+        };
+        parse_ini_profile(&content, &self.resolved_profile()).unwrap_or_else(Credentials::empty)
+    }
+}
+
+/// Parses the requested `profile` section out of credentials-file `content`.
+///
+/// Returns the credentials when both an access key and secret key are present.
+/// Matches both `[profile]` and `[profile <name>]` section headers.
+fn parse_ini_profile(content: &str, profile: &str) -> Option<Credentials> {
+    let mut in_section = false;
+    let mut access_key: Option<String> = None;
+    let mut secret_key: Option<String> = None;
+    let mut session_token: Option<String> = None;
+
+    for raw in content.lines() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        if let Some(section) = line.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+            let section = section.trim();
+            let name = section.strip_prefix("profile ").unwrap_or(section).trim();
+            in_section = name == profile;
+            continue;
+        }
+        if !in_section {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let value = value.trim().to_string();
+        match key.trim().to_ascii_lowercase().as_str() {
+            "aws_access_key_id" => access_key = Some(value),
+            "aws_secret_access_key" => secret_key = Some(value),
+            "aws_session_token" => session_token = Some(value),
+            _ => {}
+        }
+    }
+
+    match (access_key, secret_key) {
+        (Some(access_key), Some(secret_key))
+            if !access_key.is_empty() && !secret_key.is_empty() =>
+        {
+            Some(Credentials {
+                access_key,
+                secret_key,
+                session_token: session_token.filter(|v| !v.is_empty()),
+            })
+        }
+        _ => None,
+    }
+}
+
+#[async_trait]
+impl Provider for FileProvider {
+    fn fetch(&self) -> Credentials {
+        if let Some(creds) = self.cache.read().unwrap().as_ref() {
+            return creds.clone();
+        }
+        let creds = self.load();
+        *self.cache.write().unwrap() = Some(creds.clone());
+        creds
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+# comment line
+[default]
+aws_access_key_id = DEFAULT_AK
+aws_secret_access_key = DEFAULT_SK
+
+[work]
+aws_access_key_id = WORK_AK
+aws_secret_access_key = WORK_SK
+aws_session_token = WORK_TOKEN
+
+[profile spaced]
+aws_access_key_id = SPACED_AK
+aws_secret_access_key = SPACED_SK
+"#;
+
+    #[test]
+    fn parses_default_profile() {
+        let creds = parse_ini_profile(SAMPLE, "default").unwrap();
+        assert_eq!(creds.access_key, "DEFAULT_AK");
+        assert_eq!(creds.secret_key, "DEFAULT_SK");
+        assert!(creds.session_token.is_none());
+    }
+
+    #[test]
+    fn parses_named_profile_with_token() {
+        let creds = parse_ini_profile(SAMPLE, "work").unwrap();
+        assert_eq!(creds.access_key, "WORK_AK");
+        assert_eq!(creds.secret_key, "WORK_SK");
+        assert_eq!(creds.session_token.as_deref(), Some("WORK_TOKEN"));
+    }
+
+    #[test]
+    fn matches_profile_prefixed_section() {
+        let creds = parse_ini_profile(SAMPLE, "spaced").unwrap();
+        assert_eq!(creds.access_key, "SPACED_AK");
+        assert_eq!(creds.secret_key, "SPACED_SK");
+    }
+
+    #[test]
+    fn unknown_profile_returns_none() {
+        assert!(parse_ini_profile(SAMPLE, "missing").is_none());
+    }
+
+    #[test]
+    fn incomplete_profile_returns_none() {
+        let content = "[partial]\naws_access_key_id = ONLY_AK\n";
+        assert!(parse_ini_profile(content, "partial").is_none());
+    }
+}

--- a/src/s3/creds/iam.rs
+++ b/src/s3/creds/iam.rs
@@ -1,0 +1,548 @@
+// MinIO Rust Library for Amazon S3 Compatible Cloud Storage
+// Copyright 2025 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! IAM role credential provider (EC2 IMDSv2 and ECS/EKS container endpoints).
+
+use crate::s3::creds::{CachedCredentials, Credentials, Provider, refresh_deadline};
+use crate::s3::error::ValidationErr;
+use crate::s3::utils::{from_iso8601utc, utc_now};
+use async_trait::async_trait;
+use chrono::Duration;
+use std::env;
+use std::sync::RwLock;
+use std::time::Duration as StdDuration;
+
+const DEFAULT_IMDS_ENDPOINT: &str = "http://169.254.169.254";
+const ECS_LINK_LOCAL_ENDPOINT: &str = "http://169.254.170.2";
+const TOKEN_TTL_SECONDS: &str = "21600";
+const TOKEN_TTL_HEADER: &str = "X-aws-ec2-metadata-token-ttl-seconds";
+const TOKEN_HEADER: &str = "X-aws-ec2-metadata-token";
+const REQUEST_TIMEOUT: StdDuration = StdDuration::from_secs(10);
+const TOKEN_TIMEOUT: StdDuration = StdDuration::from_secs(1);
+
+/// Builds an error for IAM/ECS failures. These responses are JSON (or plain
+/// metadata), so a neutral string error is used rather than an XML error.
+fn creds_error(message: impl Into<String>) -> ValidationErr {
+    ValidationErr::StrError {
+        message: message.into(),
+        source: None,
+    }
+}
+
+/// Credential provider that obtains temporary credentials from an EC2 instance
+/// (IMDSv2) or from the ECS/EKS container credentials endpoint.
+///
+/// When `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` or
+/// `AWS_CONTAINER_CREDENTIALS_FULL_URI` is set, the container endpoint is used;
+/// otherwise the EC2 instance metadata service is queried using IMDSv2 (a token
+/// is fetched first, then the instance role's credentials). The IMDS endpoint
+/// defaults to `http://169.254.169.254` and can be overridden via
+/// `AWS_EC2_METADATA_SERVICE_ENDPOINT` or [`IamRoleProvider::endpoint`].
+///
+/// Like other network-backed providers, [`Provider::fetch`] returns the cached
+/// credentials; call [`Provider::ensure_credentials`] (awaited) to perform the
+/// initial fetch and subsequent refreshes.
+#[derive(Debug)]
+pub struct IamRoleProvider {
+    endpoint: Option<String>,
+    cache: RwLock<Option<CachedCredentials>>,
+}
+
+impl Default for IamRoleProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct IamCredentialsResponse {
+    #[serde(rename = "Code")]
+    code: Option<String>,
+    #[serde(rename = "AccessKeyId")]
+    access_key_id: Option<String>,
+    #[serde(rename = "SecretAccessKey")]
+    secret_access_key: Option<String>,
+    #[serde(rename = "Token")]
+    token: Option<String>,
+    #[serde(rename = "Expiration")]
+    expiration: Option<String>,
+}
+
+impl IamRoleProvider {
+    /// Returns a provider using the default IMDS endpoint (or the container
+    /// endpoint when the relevant environment variables are present).
+    pub fn new() -> Self {
+        IamRoleProvider {
+            endpoint: None,
+            cache: RwLock::new(None),
+        }
+    }
+
+    /// Overrides the EC2 instance metadata service endpoint.
+    pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.endpoint = Some(endpoint.into());
+        self
+    }
+
+    fn imds_endpoint(&self) -> String {
+        if let Some(endpoint) = &self.endpoint {
+            return endpoint.trim_end_matches('/').to_string();
+        }
+        env::var("AWS_EC2_METADATA_SERVICE_ENDPOINT")
+            .ok()
+            .filter(|v| !v.is_empty())
+            .map(|v| v.trim_end_matches('/').to_string())
+            .unwrap_or_else(|| DEFAULT_IMDS_ENDPOINT.to_string())
+    }
+
+    /// Performs the credential fetch and stores the result in the cache.
+    pub async fn refresh(&self) -> Result<Credentials, ValidationErr> {
+        let client = reqwest::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .map_err(ValidationErr::from)?;
+
+        let body = match container_source() {
+            // The relative URI is pinned to the link-local ECS endpoint, so the
+            // authorization token is always safe to attach.
+            Some(ContainerSource::Relative(url)) => {
+                self.fetch_container(&client, &url, true).await?
+            }
+            // For an arbitrary full URI, only attach the bearer token when the
+            // target is loopback/link-local or https, so it cannot be exfiltrated
+            // to a remote cleartext host (mirrors minio-go's loopback guard).
+            Some(ContainerSource::Full(url)) => {
+                let attach_token = token_target_is_safe(&url);
+                self.fetch_container(&client, &url, attach_token).await?
+            }
+            None => self.fetch_imds(&client).await?,
+        };
+
+        let cached = parse_iam_response(&body)?;
+        let creds = cached.creds.clone();
+        *self.cache.write().unwrap() = Some(cached);
+        Ok(creds)
+    }
+
+    async fn fetch_container(
+        &self,
+        client: &reqwest::Client,
+        url: &str,
+        attach_token: bool,
+    ) -> Result<String, ValidationErr> {
+        let mut request = client.get(url);
+        if attach_token && let Some(token) = container_authorization_token() {
+            request = request.header("Authorization", token);
+        }
+        let response = request.send().await.map_err(ValidationErr::from)?;
+        let status = response.status();
+        let text = response.text().await?;
+        if !status.is_success() {
+            return Err(creds_error(format!(
+                "container credentials request failed with status {status}: {text}"
+            )));
+        }
+        Ok(text)
+    }
+
+    async fn fetch_imds(&self, client: &reqwest::Client) -> Result<String, ValidationErr> {
+        let base = self.imds_endpoint();
+
+        // Fetch an IMDSv2 session token with a short timeout. If it is
+        // unavailable (timeout, or a host that only speaks IMDSv1), proceed
+        // without a token so the credential GETs fall back to IMDSv1, matching
+        // minio-go's behavior.
+        let token: Option<String> = match client
+            .put(format!("{base}/latest/api/token"))
+            .header(TOKEN_TTL_HEADER, TOKEN_TTL_SECONDS)
+            .timeout(TOKEN_TIMEOUT)
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => resp.text().await.ok(),
+            _ => None,
+        };
+
+        let role = self
+            .imds_get(
+                client,
+                format!("{base}/latest/meta-data/iam/security-credentials/"),
+                &token,
+            )
+            .await?;
+        let role = role.trim();
+        if role.is_empty() {
+            return Err(creds_error("no IAM role found in instance metadata"));
+        }
+
+        self.imds_get(
+            client,
+            format!("{base}/latest/meta-data/iam/security-credentials/{role}"),
+            &token,
+        )
+        .await
+    }
+
+    async fn imds_get(
+        &self,
+        client: &reqwest::Client,
+        url: String,
+        token: &Option<String>,
+    ) -> Result<String, ValidationErr> {
+        let mut request = client.get(url);
+        if let Some(token) = token {
+            request = request.header(TOKEN_HEADER, token);
+        }
+        let body = request
+            .send()
+            .await
+            .map_err(ValidationErr::from)?
+            .error_for_status()
+            .map_err(ValidationErr::from)?
+            .text()
+            .await?;
+        Ok(body)
+    }
+}
+
+enum ContainerSource {
+    /// ECS relative URI, pinned to the link-local endpoint.
+    Relative(String),
+    /// Arbitrary full URI from `AWS_CONTAINER_CREDENTIALS_FULL_URI`.
+    Full(String),
+}
+
+fn container_source() -> Option<ContainerSource> {
+    if let Ok(relative) = env::var("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+        && !relative.is_empty()
+    {
+        return Some(ContainerSource::Relative(format!(
+            "{ECS_LINK_LOCAL_ENDPOINT}{relative}"
+        )));
+    }
+    env::var("AWS_CONTAINER_CREDENTIALS_FULL_URI")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .map(ContainerSource::Full)
+}
+
+/// Returns true when the container authorization token may safely be sent to
+/// `url`: an https endpoint, or a loopback/link-local host. This prevents the
+/// bearer token from being exfiltrated to an arbitrary remote cleartext host,
+/// matching minio-go's loopback guard for `AWS_CONTAINER_CREDENTIALS_FULL_URI`.
+fn token_target_is_safe(url: &str) -> bool {
+    let Ok(parsed) = reqwest::Url::parse(url) else {
+        return false;
+    };
+    if parsed.scheme() == "https" {
+        return true;
+    }
+    match parsed.host() {
+        Some(url::Host::Domain(host)) => host == "localhost",
+        Some(url::Host::Ipv4(ip)) => ip.is_loopback() || ip.is_link_local(),
+        Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
+        None => false,
+    }
+}
+
+fn container_authorization_token() -> Option<String> {
+    if let Ok(token) = env::var("AWS_CONTAINER_AUTHORIZATION_TOKEN")
+        && !token.is_empty()
+    {
+        return Some(token);
+    }
+    let path = env::var("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE")
+        .ok()
+        .filter(|v| !v.is_empty())?;
+    std::fs::read_to_string(path)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+/// Parses the JSON credentials document returned by the IMDS/ECS endpoints.
+fn parse_iam_response(json: &str) -> Result<CachedCredentials, ValidationErr> {
+    let now = utc_now();
+    let parsed: IamCredentialsResponse = serde_json::from_str(json)
+        .map_err(|e| creds_error(format!("invalid IAM credentials response: {e}")))?;
+
+    if let Some(code) = &parsed.code
+        && code != "Success"
+    {
+        return Err(creds_error(format!(
+            "IAM credentials request returned code {code}"
+        )));
+    }
+
+    let access_key = parsed
+        .access_key_id
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| creds_error("missing AccessKeyId in IAM credentials response"))?;
+    let secret_key = parsed
+        .secret_access_key
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| creds_error("missing SecretAccessKey in IAM credentials response"))?;
+    let session_token = parsed.token.filter(|v| !v.is_empty());
+
+    let expiration = match parsed.expiration {
+        Some(value) => from_iso8601utc(&value)?,
+        None => now + Duration::hours(1),
+    };
+
+    Ok(CachedCredentials {
+        creds: Credentials {
+            access_key,
+            secret_key,
+            session_token,
+        },
+        refresh_after: refresh_deadline(now, expiration),
+    })
+}
+
+#[async_trait]
+impl Provider for IamRoleProvider {
+    fn fetch(&self) -> Credentials {
+        self.cache
+            .read()
+            .unwrap()
+            .as_ref()
+            .map(|cached| cached.creds.clone())
+            .unwrap_or_else(Credentials::empty)
+    }
+
+    async fn ensure_credentials(&self) -> Result<Credentials, ValidationErr> {
+        if let Some(cached) = self.cache.read().unwrap().as_ref()
+            && utc_now() < cached.refresh_after
+        {
+            return Ok(cached.creds.clone());
+        }
+        self.refresh().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_successful_response() {
+        let json = r#"{
+            "Code": "Success",
+            "AccessKeyId": "AKIDTEST",
+            "SecretAccessKey": "SECRETTEST",
+            "Token": "TOKENTEST",
+            "Expiration": "2030-01-01T00:00:00Z"
+        }"#;
+        let cached = parse_iam_response(json).unwrap();
+        assert_eq!(cached.creds.access_key, "AKIDTEST");
+        assert_eq!(cached.creds.secret_key, "SECRETTEST");
+        assert_eq!(cached.creds.session_token.as_deref(), Some("TOKENTEST"));
+        assert!(cached.refresh_after > utc_now());
+    }
+
+    #[test]
+    fn parses_container_response_without_code() {
+        let json = r#"{
+            "AccessKeyId": "AKID",
+            "SecretAccessKey": "SECRET",
+            "Token": "TOKEN",
+            "Expiration": "2030-01-01T00:00:00Z"
+        }"#;
+        let cached = parse_iam_response(json).unwrap();
+        assert_eq!(cached.creds.access_key, "AKID");
+    }
+
+    #[test]
+    fn rejects_non_success_code() {
+        let json = r#"{"Code": "AssumeRoleUnauthorizedAccess"}"#;
+        assert!(matches!(
+            parse_iam_response(json),
+            Err(ValidationErr::StrError { .. })
+        ));
+    }
+
+    #[test]
+    fn token_target_safety() {
+        assert!(token_target_is_safe("https://creds.example.com/path"));
+        assert!(token_target_is_safe("http://127.0.0.1:8080/creds"));
+        assert!(token_target_is_safe("http://localhost/creds"));
+        assert!(token_target_is_safe("http://169.254.170.2/v2/creds"));
+        assert!(!token_target_is_safe("http://evil.example.com/creds"));
+        assert!(!token_target_is_safe("not a url"));
+    }
+
+    #[test]
+    fn rejects_missing_keys() {
+        let json = r#"{"Code": "Success", "AccessKeyId": "AKID"}"#;
+        assert!(parse_iam_response(json).is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_json() {
+        assert!(parse_iam_response("not json").is_err());
+    }
+
+    #[test]
+    fn fetch_empty_before_priming() {
+        assert!(IamRoleProvider::new().fetch().is_empty());
+    }
+
+    mod network {
+        use super::*;
+        use crate::s3::creds::mock_http::{self, Request, Responder};
+        use std::sync::Arc;
+        use std::sync::LazyLock;
+        use tokio::sync::Mutex;
+
+        const CREDS_JSON: &str = r#"{
+            "Code": "Success",
+            "AccessKeyId": "IMDSAK",
+            "SecretAccessKey": "IMDSSK",
+            "Token": "IMDSTOKEN",
+            "Expiration": "2030-01-01T00:00:00Z"
+        }"#;
+
+        // Serializes the network-flow tests: refresh() consults the container
+        // environment variables first, so an ECS test setting them must not run
+        // concurrently with an IMDS test.
+        static NET_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+        fn clear_container_env() {
+            for key in [
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+                "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+                "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+                "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+            ] {
+                unsafe { env::remove_var(key) };
+            }
+        }
+
+        #[tokio::test]
+        async fn imdsv2_full_flow_uses_token() {
+            let _guard = NET_LOCK.lock().await;
+            clear_container_env();
+
+            // Role and credential endpoints require the IMDSv2 token, proving the
+            // client fetched it via the token PUT and forwarded it.
+            let responder: Responder = Arc::new(|req: &Request| {
+                if req.method == "PUT" && req.path == "/latest/api/token" {
+                    return (200, "imds-session-token".to_string());
+                }
+                if req.headers.get(&TOKEN_HEADER.to_ascii_lowercase())
+                    != Some(&"imds-session-token".to_string())
+                {
+                    return (401, String::new());
+                }
+                match req.path.as_str() {
+                    "/latest/meta-data/iam/security-credentials/" => (200, "RoleName".to_string()),
+                    "/latest/meta-data/iam/security-credentials/RoleName" => {
+                        (200, CREDS_JSON.to_string())
+                    }
+                    _ => (404, String::new()),
+                }
+            });
+            let server = mock_http::start(responder).await;
+
+            let creds = IamRoleProvider::new()
+                .endpoint(&server.base_url)
+                .refresh()
+                .await
+                .unwrap();
+            assert_eq!(creds.access_key, "IMDSAK");
+            assert_eq!(creds.secret_key, "IMDSSK");
+            assert_eq!(creds.session_token.as_deref(), Some("IMDSTOKEN"));
+        }
+
+        #[tokio::test]
+        async fn imdsv1_fallback_when_token_blocked() {
+            let _guard = NET_LOCK.lock().await;
+            clear_container_env();
+
+            // Token endpoint is blocked (403, as with IMDSv1-only hosts); the
+            // metadata endpoints serve credentials without requiring a token.
+            let responder: Responder = Arc::new(|req: &Request| {
+                if req.method == "PUT" && req.path == "/latest/api/token" {
+                    return (403, String::new());
+                }
+                match req.path.as_str() {
+                    "/latest/meta-data/iam/security-credentials/" => (200, "RoleName".to_string()),
+                    "/latest/meta-data/iam/security-credentials/RoleName" => {
+                        (200, CREDS_JSON.to_string())
+                    }
+                    _ => (404, String::new()),
+                }
+            });
+            let server = mock_http::start(responder).await;
+
+            let creds = IamRoleProvider::new()
+                .endpoint(&server.base_url)
+                .refresh()
+                .await
+                .unwrap();
+            assert_eq!(creds.access_key, "IMDSAK");
+        }
+
+        #[tokio::test]
+        async fn imds_no_role_errors() {
+            let _guard = NET_LOCK.lock().await;
+            clear_container_env();
+
+            let responder: Responder = Arc::new(|req: &Request| {
+                if req.method == "PUT" && req.path == "/latest/api/token" {
+                    return (200, "tok".to_string());
+                }
+                // Empty role listing.
+                (200, String::new())
+            });
+            let server = mock_http::start(responder).await;
+
+            let result = IamRoleProvider::new()
+                .endpoint(&server.base_url)
+                .refresh()
+                .await;
+            assert!(result.is_err());
+        }
+
+        #[tokio::test]
+        async fn ecs_full_uri_flow() {
+            let _guard = NET_LOCK.lock().await;
+            clear_container_env();
+
+            let responder: Responder = Arc::new(|req: &Request| {
+                if req.path == "/v2/credentials" {
+                    (200, CREDS_JSON.to_string())
+                } else {
+                    (404, String::new())
+                }
+            });
+            let server = mock_http::start(responder).await;
+
+            // Loopback host, so the authorization token (if any) is allowed.
+            unsafe {
+                env::set_var(
+                    "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+                    format!("{}/v2/credentials", server.base_url),
+                );
+            }
+            let creds = IamRoleProvider::new().refresh().await;
+            clear_container_env();
+
+            let creds = creds.unwrap();
+            assert_eq!(creds.access_key, "IMDSAK");
+            assert_eq!(creds.session_token.as_deref(), Some("IMDSTOKEN"));
+        }
+    }
+}

--- a/src/s3/creds/iam.rs
+++ b/src/s3/creds/iam.rs
@@ -402,9 +402,8 @@ mod tests {
     mod network {
         use super::*;
         use crate::s3::creds::mock_http::{self, Request, Responder};
+        use crate::s3::creds::test_support::ENV_LOCK;
         use std::sync::Arc;
-        use std::sync::LazyLock;
-        use tokio::sync::Mutex;
 
         const CREDS_JSON: &str = r#"{
             "Code": "Success",
@@ -413,11 +412,6 @@ mod tests {
             "Token": "IMDSTOKEN",
             "Expiration": "2030-01-01T00:00:00Z"
         }"#;
-
-        // Serializes the network-flow tests: refresh() consults the container
-        // environment variables first, so an ECS test setting them must not run
-        // concurrently with an IMDS test.
-        static NET_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
         fn clear_container_env() {
             for key in [
@@ -432,7 +426,7 @@ mod tests {
 
         #[tokio::test]
         async fn imdsv2_full_flow_uses_token() {
-            let _guard = NET_LOCK.lock().await;
+            let _guard = ENV_LOCK.lock().await;
             clear_container_env();
 
             // Role and credential endpoints require the IMDSv2 token, proving the
@@ -468,7 +462,7 @@ mod tests {
 
         #[tokio::test]
         async fn imdsv1_fallback_when_token_blocked() {
-            let _guard = NET_LOCK.lock().await;
+            let _guard = ENV_LOCK.lock().await;
             clear_container_env();
 
             // Token endpoint is blocked (403, as with IMDSv1-only hosts); the
@@ -497,7 +491,7 @@ mod tests {
 
         #[tokio::test]
         async fn imds_no_role_errors() {
-            let _guard = NET_LOCK.lock().await;
+            let _guard = ENV_LOCK.lock().await;
             clear_container_env();
 
             let responder: Responder = Arc::new(|req: &Request| {
@@ -518,7 +512,7 @@ mod tests {
 
         #[tokio::test]
         async fn ecs_full_uri_flow() {
-            let _guard = NET_LOCK.lock().await;
+            let _guard = ENV_LOCK.lock().await;
             clear_container_env();
 
             let responder: Responder = Arc::new(|req: &Request| {

--- a/src/s3/creds/mock_http.rs
+++ b/src/s3/creds/mock_http.rs
@@ -140,3 +140,54 @@ fn content_length(header_text: &str) -> usize {
 fn find_header_end(data: &[u8]) -> Option<usize> {
     data.windows(4).position(|w| w == b"\r\n\r\n")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_header_end_locates_blank_line() {
+        assert_eq!(find_header_end(b"AB\r\n\r\nCD"), Some(2));
+        assert_eq!(find_header_end(b"no terminator\r\n"), None);
+    }
+
+    #[test]
+    fn content_length_parses_when_present() {
+        assert_eq!(
+            content_length("POST / HTTP/1.1\r\nContent-Length: 42\r\n"),
+            42
+        );
+        assert_eq!(content_length("content-length: 7"), 7);
+        assert_eq!(content_length("GET / HTTP/1.1"), 0);
+        assert_eq!(content_length("Content-Length: not-a-number"), 0);
+    }
+
+    #[tokio::test]
+    async fn round_trip_routes_by_method_and_path() {
+        let responder: Responder = Arc::new(|req: &Request| {
+            if req.method == "POST" && req.path == "/echo" {
+                (200, "ok".to_string())
+            } else {
+                (404, String::new())
+            }
+        });
+        let server = start(responder).await;
+        let client = reqwest::Client::new();
+
+        let resp = client
+            .post(format!("{}/echo", server.base_url))
+            .body("hello")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        assert_eq!(resp.text().await.unwrap(), "ok");
+
+        let resp = client
+            .get(format!("{}/missing", server.base_url))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 404);
+    }
+}

--- a/src/s3/creds/mock_http.rs
+++ b/src/s3/creds/mock_http.rs
@@ -1,0 +1,142 @@
+// MinIO Rust Library for Amazon S3 Compatible Cloud Storage
+// Copyright 2025 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Minimal in-process HTTP server for exercising the network credential
+//! providers (IMDS/ECS/STS) end-to-end in unit tests, mirroring the
+//! `httptest`-based tests in minio-go's `credentials` package.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// Parsed request: method, path, and lowercase-keyed headers.
+pub(crate) struct Request {
+    pub(crate) method: String,
+    pub(crate) path: String,
+    pub(crate) headers: HashMap<String, String>,
+}
+
+/// Maps an incoming request to a `(status, body)` response.
+pub(crate) type Responder = Arc<dyn Fn(&Request) -> (u16, String) + Send + Sync>;
+
+/// A running mock HTTP server. The server stops when this is dropped.
+pub(crate) struct MockServer {
+    pub(crate) base_url: String,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for MockServer {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+/// Starts a mock server on an ephemeral loopback port. Each request is routed
+/// through `responder`; the connection is closed after every response so the
+/// client (reqwest) issues a fresh connection per request.
+pub(crate) async fn start(responder: Responder) -> MockServer {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let base_url = format!("http://{addr}");
+
+    let handle = tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                break;
+            };
+            let responder = responder.clone();
+            tokio::spawn(async move {
+                let Some(request) = read_request(&mut sock).await else {
+                    return;
+                };
+                let (status, body) = responder(&request);
+                let reason = if (200..300).contains(&status) {
+                    "OK"
+                } else {
+                    "Error"
+                };
+                let response = format!(
+                    "HTTP/1.1 {status} {reason}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = sock.write_all(response.as_bytes()).await;
+                let _ = sock.flush().await;
+            });
+        }
+    });
+
+    MockServer { base_url, handle }
+}
+
+/// Reads a full request (headers and, when present, the Content-Length body) so
+/// the client's write completes before the response is sent, then parses the
+/// request line and headers.
+async fn read_request(sock: &mut tokio::net::TcpStream) -> Option<Request> {
+    let mut data = Vec::new();
+    let mut buf = [0u8; 1024];
+    let header_end = loop {
+        let n = sock.read(&mut buf).await.ok()?;
+        if n == 0 {
+            break find_header_end(&data)?;
+        }
+        data.extend_from_slice(&buf[..n]);
+
+        if let Some(pos) = find_header_end(&data) {
+            let header_text = String::from_utf8_lossy(&data[..pos]);
+            let content_length = content_length(&header_text);
+            let body_received = data.len() - (pos + 4);
+            if body_received >= content_length {
+                break pos;
+            }
+        }
+    };
+
+    let header_text = String::from_utf8_lossy(&data[..header_end]);
+    let mut lines = header_text.lines();
+    let mut request_line = lines.next()?.split_whitespace();
+    let method = request_line.next()?.to_string();
+    let path = request_line.next()?.to_string();
+
+    let headers = lines
+        .filter_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            Some((name.trim().to_ascii_lowercase(), value.trim().to_string()))
+        })
+        .collect();
+
+    Some(Request {
+        method,
+        path,
+        headers,
+    })
+}
+
+fn content_length(header_text: &str) -> usize {
+    header_text
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.trim()
+                .eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().ok())
+                .flatten()
+        })
+        .unwrap_or(0)
+}
+
+fn find_header_end(data: &[u8]) -> Option<usize> {
+    data.windows(4).position(|w| w == b"\r\n\r\n")
+}

--- a/src/s3/creds/test_support.rs
+++ b/src/s3/creds/test_support.rs
@@ -1,0 +1,28 @@
+// MinIO Rust Library for Amazon S3 Compatible Cloud Storage
+// Copyright 2025 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared helpers for credential-provider tests.
+
+use std::sync::LazyLock;
+use tokio::sync::Mutex;
+
+/// Process-wide lock serializing every test that mutates environment variables.
+///
+/// `std::env::set_var`/`remove_var` affect the whole process, and tests run in
+/// parallel, so all credential-provider tests touching the environment (env,
+/// file, IAM/ECS, web-identity) must hold this single lock. Synchronous `#[test]`
+/// tests acquire it with `ENV_LOCK.blocking_lock()`; async `#[tokio::test]` tests
+/// use `ENV_LOCK.lock().await`.
+pub(crate) static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));

--- a/src/s3/creds/web_identity.rs
+++ b/src/s3/creds/web_identity.rs
@@ -1,0 +1,314 @@
+// MinIO Rust Library for Amazon S3 Compatible Cloud Storage
+// Copyright 2025 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Web-identity STS credential provider (`AssumeRoleWithWebIdentity`).
+
+use crate::s3::creds::{
+    CachedCredentials, Credentials, Provider, STS_VERSION, parse_sts_credentials, xml_error,
+};
+use crate::s3::error::ValidationErr;
+use crate::s3::utils::utc_now;
+use async_trait::async_trait;
+use std::env;
+use std::path::PathBuf;
+use std::sync::RwLock;
+use std::time::Duration as StdDuration;
+
+const REQUEST_TIMEOUT: StdDuration = StdDuration::from_secs(60);
+const DEFAULT_SESSION_NAME: &str = "minio-rs-web-identity";
+
+/// Credential provider that obtains temporary credentials from an STS endpoint
+/// via the [`AssumeRoleWithWebIdentity`](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html)
+/// action, using an OIDC/JWT token (e.g. an EKS service-account token).
+///
+/// The role ARN, web-identity token file, and session name default to the
+/// `AWS_ROLE_ARN`, `AWS_WEB_IDENTITY_TOKEN_FILE`, and `AWS_ROLE_SESSION_NAME`
+/// environment variables respectively, and may be overridden with the builder
+/// methods. Like other network-backed providers, [`Provider::fetch`] returns
+/// cached credentials; call [`Provider::ensure_credentials`] to perform the
+/// exchange.
+#[derive(Debug)]
+pub struct WebIdentityProvider {
+    sts_endpoint: String,
+    role_arn: Option<String>,
+    role_session_name: Option<String>,
+    token_file: Option<PathBuf>,
+    duration_seconds: Option<u32>,
+    policy: Option<String>,
+    cache: RwLock<Option<CachedCredentials>>,
+}
+
+impl WebIdentityProvider {
+    /// Returns a new provider targeting `sts_endpoint`, reading the role ARN,
+    /// token file, and session name from the environment unless overridden.
+    pub fn new(sts_endpoint: impl Into<String>) -> Self {
+        WebIdentityProvider {
+            sts_endpoint: sts_endpoint.into(),
+            role_arn: None,
+            role_session_name: None,
+            token_file: None,
+            duration_seconds: None,
+            policy: None,
+            cache: RwLock::new(None),
+        }
+    }
+
+    /// Overrides the role ARN (`RoleArn`).
+    pub fn role_arn(mut self, role_arn: impl Into<String>) -> Self {
+        self.role_arn = Some(role_arn.into());
+        self
+    }
+
+    /// Overrides the role session name (`RoleSessionName`).
+    pub fn role_session_name(mut self, name: impl Into<String>) -> Self {
+        self.role_session_name = Some(name.into());
+        self
+    }
+
+    /// Overrides the path to the file containing the web-identity token.
+    pub fn token_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.token_file = Some(path.into());
+        self
+    }
+
+    /// Sets the requested credential lifetime in seconds (`DurationSeconds`).
+    pub fn duration_seconds(mut self, seconds: u32) -> Self {
+        self.duration_seconds = Some(seconds);
+        self
+    }
+
+    /// Sets the session policy applied to the generated credentials.
+    pub fn policy(mut self, policy: impl Into<String>) -> Self {
+        self.policy = Some(policy.into());
+        self
+    }
+
+    fn resolved_role_arn(&self) -> Result<String, ValidationErr> {
+        self.role_arn
+            .clone()
+            .or_else(|| env::var("AWS_ROLE_ARN").ok().filter(|v| !v.is_empty()))
+            .ok_or_else(|| xml_error("web identity role ARN is not set (AWS_ROLE_ARN)"))
+    }
+
+    fn resolved_session_name(&self) -> String {
+        self.role_session_name
+            .clone()
+            .or_else(|| {
+                env::var("AWS_ROLE_SESSION_NAME")
+                    .ok()
+                    .filter(|v| !v.is_empty())
+            })
+            .unwrap_or_else(|| DEFAULT_SESSION_NAME.to_string())
+    }
+
+    fn read_token(&self) -> Result<String, ValidationErr> {
+        let path = match &self.token_file {
+            Some(path) => path.clone(),
+            None => env::var("AWS_WEB_IDENTITY_TOKEN_FILE")
+                .ok()
+                .filter(|v| !v.is_empty())
+                .map(PathBuf::from)
+                .ok_or_else(|| {
+                    xml_error("web identity token file is not set (AWS_WEB_IDENTITY_TOKEN_FILE)")
+                })?,
+        };
+        let token = std::fs::read_to_string(&path)
+            .map_err(|e| xml_error(&format!("failed to read web identity token file: {e}")))?;
+        Ok(token.trim().to_string())
+    }
+
+    /// Builds the form-urlencoded STS request body for the given token.
+    fn build_request_body(&self, token: &str) -> Result<String, ValidationErr> {
+        let role_arn = self.resolved_role_arn()?;
+        let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+        serializer
+            .append_pair("Action", "AssumeRoleWithWebIdentity")
+            .append_pair("Version", STS_VERSION)
+            .append_pair("RoleArn", &role_arn)
+            .append_pair("RoleSessionName", &self.resolved_session_name())
+            .append_pair("WebIdentityToken", token);
+        if let Some(duration) = self.duration_seconds {
+            serializer.append_pair("DurationSeconds", &duration.to_string());
+        }
+        if let Some(policy) = &self.policy {
+            serializer.append_pair("Policy", policy);
+        }
+        Ok(serializer.finish())
+    }
+
+    /// Performs the STS exchange and stores the result in the cache.
+    pub async fn refresh(&self) -> Result<Credentials, ValidationErr> {
+        let token = self.read_token()?;
+        let body = self.build_request_body(&token)?;
+
+        let response = reqwest::Client::new()
+            .post(&self.sts_endpoint)
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .body(body)
+            .timeout(REQUEST_TIMEOUT)
+            .send()
+            .await
+            .map_err(ValidationErr::from)?;
+
+        let status = response.status();
+        let text = response.text().await?;
+        if !status.is_success() {
+            return Err(xml_error(&format!(
+                "STS AssumeRoleWithWebIdentity failed with status {status}: {text}"
+            )));
+        }
+
+        let cached = parse_sts_credentials(&text, "AssumeRoleWithWebIdentityResult")?;
+        let creds = cached.creds.clone();
+        *self.cache.write().unwrap() = Some(cached);
+        Ok(creds)
+    }
+}
+
+#[async_trait]
+impl Provider for WebIdentityProvider {
+    fn fetch(&self) -> Credentials {
+        self.cache
+            .read()
+            .unwrap()
+            .as_ref()
+            .map(|cached| cached.creds.clone())
+            .unwrap_or_else(Credentials::empty)
+    }
+
+    async fn ensure_credentials(&self) -> Result<Credentials, ValidationErr> {
+        if let Some(cached) = self.cache.read().unwrap().as_ref()
+            && utc_now() < cached.refresh_after
+        {
+            return Ok(cached.creds.clone());
+        }
+        self.refresh().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn parse_body(body: &str) -> HashMap<String, String> {
+        url::form_urlencoded::parse(body.as_bytes())
+            .into_owned()
+            .collect()
+    }
+
+    #[test]
+    fn build_request_body_minimal() {
+        let provider = WebIdentityProvider::new("http://localhost:9000")
+            .role_arn("arn:aws:iam::123:role/test");
+        let params = parse_body(&provider.build_request_body("jwt-token").unwrap());
+        assert_eq!(params["Action"], "AssumeRoleWithWebIdentity");
+        assert_eq!(params["Version"], "2011-06-15");
+        assert_eq!(params["RoleArn"], "arn:aws:iam::123:role/test");
+        assert_eq!(params["RoleSessionName"], DEFAULT_SESSION_NAME);
+        assert_eq!(params["WebIdentityToken"], "jwt-token");
+        assert!(!params.contains_key("DurationSeconds"));
+        assert!(!params.contains_key("Policy"));
+    }
+
+    #[test]
+    fn build_request_body_with_options() {
+        let provider = WebIdentityProvider::new("http://localhost:9000")
+            .role_arn("arn:aws:iam::123:role/test")
+            .role_session_name("session-1")
+            .duration_seconds(900)
+            .policy("{\"Version\":\"2012-10-17\"}");
+        let params = parse_body(&provider.build_request_body("jwt").unwrap());
+        assert_eq!(params["RoleSessionName"], "session-1");
+        assert_eq!(params["DurationSeconds"], "900");
+        assert_eq!(params["Policy"], "{\"Version\":\"2012-10-17\"}");
+    }
+
+    #[test]
+    fn build_request_body_without_role_arn_errors() {
+        // Avoid leaking AWS_ROLE_ARN from the test environment.
+        let prev = env::var("AWS_ROLE_ARN").ok();
+        unsafe { env::remove_var("AWS_ROLE_ARN") };
+        let provider = WebIdentityProvider::new("http://localhost:9000");
+        assert!(provider.build_request_body("jwt").is_err());
+        if let Some(v) = prev {
+            unsafe { env::set_var("AWS_ROLE_ARN", v) };
+        }
+    }
+
+    #[test]
+    fn parses_web_identity_response() {
+        let xml = r#"<?xml version="1.0"?>
+<AssumeRoleWithWebIdentityResponse>
+  <AssumeRoleWithWebIdentityResult>
+    <Credentials>
+      <AccessKeyId>AKID</AccessKeyId>
+      <SecretAccessKey>SECRET</SecretAccessKey>
+      <SessionToken>TOKEN</SessionToken>
+      <Expiration>2030-01-01T00:00:00Z</Expiration>
+    </Credentials>
+  </AssumeRoleWithWebIdentityResult>
+</AssumeRoleWithWebIdentityResponse>"#;
+        let cached = parse_sts_credentials(xml, "AssumeRoleWithWebIdentityResult").unwrap();
+        assert_eq!(cached.creds.access_key, "AKID");
+        assert_eq!(cached.creds.session_token.as_deref(), Some("TOKEN"));
+    }
+
+    #[test]
+    fn fetch_empty_before_priming() {
+        assert!(
+            WebIdentityProvider::new("http://localhost:9000")
+                .fetch()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn web_identity_sts_flow() {
+        use crate::s3::creds::mock_http::{self, Request, Responder};
+        use std::sync::Arc;
+
+        const STS_XML: &str = r#"<?xml version="1.0"?>
+<AssumeRoleWithWebIdentityResponse><AssumeRoleWithWebIdentityResult><Credentials>
+<AccessKeyId>WIDAK</AccessKeyId><SecretAccessKey>WIDSK</SecretAccessKey>
+<SessionToken>WIDTOKEN</SessionToken><Expiration>2030-01-01T00:00:00Z</Expiration>
+</Credentials></AssumeRoleWithWebIdentityResult></AssumeRoleWithWebIdentityResponse>"#;
+
+        let responder: Responder = Arc::new(|req: &Request| {
+            if req.method == "POST" {
+                (200, STS_XML.to_string())
+            } else {
+                (404, String::new())
+            }
+        });
+        let server = mock_http::start(responder).await;
+
+        let token_path =
+            std::env::temp_dir().join(format!("minio-rs-webid-{}.jwt", std::process::id()));
+        std::fs::write(&token_path, "jwt-token").unwrap();
+
+        let creds = WebIdentityProvider::new(&server.base_url)
+            .role_arn("arn:aws:iam::123456789012:role/test")
+            .token_file(token_path.clone())
+            .refresh()
+            .await
+            .unwrap();
+        let _ = std::fs::remove_file(&token_path);
+
+        assert_eq!(creds.access_key, "WIDAK");
+        assert_eq!(creds.secret_key, "WIDSK");
+        assert_eq!(creds.session_token.as_deref(), Some("WIDTOKEN"));
+    }
+}

--- a/src/s3/creds/web_identity.rs
+++ b/src/s3/creds/web_identity.rs
@@ -238,7 +238,9 @@ mod tests {
 
     #[test]
     fn build_request_body_without_role_arn_errors() {
-        // Avoid leaking AWS_ROLE_ARN from the test environment.
+        // Serialize with other env-mutating credential tests, and avoid leaking
+        // AWS_ROLE_ARN from the test environment.
+        let _guard = crate::s3::creds::test_support::ENV_LOCK.blocking_lock();
         let prev = env::var("AWS_ROLE_ARN").ok();
         unsafe { env::remove_var("AWS_ROLE_ARN") };
         let provider = WebIdentityProvider::new("http://localhost:9000");

--- a/src/s3/types/header_constants.rs
+++ b/src/s3/types/header_constants.rs
@@ -112,6 +112,8 @@ pub const X_AMZ_COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5: &str =
 
 pub const X_AMZ_CHECKSUM_ALGORITHM: &str = "X-Amz-Checksum-Algorithm";
 
+pub const X_AMZ_CHECKSUM_MODE: &str = "X-Amz-Checksum-Mode";
+
 pub const X_AMZ_CHECKSUM_CRC32: &str = "X-Amz-Checksum-CRC32";
 
 pub const X_AMZ_CHECKSUM_CRC32C: &str = "X-Amz-Checksum-CRC32C";
@@ -141,6 +143,8 @@ pub const X_AMZ_MAX_PARTS: &str = "X-Amz-Max-Parts";
 pub const X_AMZ_PART_NUMBER_MARKER: &str = "X-Amz-Part-Number-Marker";
 
 pub const X_AMZ_RENAME_SOURCE: &str = "x-amz-rename-source";
+
+pub const X_AMZ_STORAGE_CLASS: &str = "X-Amz-Storage-Class";
 
 pub const X_AMZ_RENAME_SOURCE_IF_MATCH: &str = "x-amz-rename-source-if-match";
 

--- a/src/s3/types/s3_request.rs
+++ b/src/s3/types/s3_request.rs
@@ -53,7 +53,7 @@ pub struct S3Request {
     pub(crate) query_params: Multimap,
 
     #[builder(default)]
-    headers: Multimap,
+    pub(crate) headers: Multimap,
 
     #[builder(default, setter(into))]
     body: Option<Arc<SegmentedBytes>>,


### PR DESCRIPTION
## What

Three additions to bring the SDK in line with minio-go for write/auth options that downstreams (e.g. minfs) need:

### 1. `x-amz-storage-class` on writes
A `storage_class` setter on the `PutObject`, `PutObjectContent`, `CreateMultipartUpload`, and `CopyObject` builders. For multipart uploads the storage class is set on `CreateMultipartUpload` (not per part); `CopyObject` carries it through both the direct copy and the >5 GiB compose path.

### 2. `x-amz-checksum-mode` on GET/HEAD (request side)
`enable_checksum(true)` on `GetObject` and `StatObject` emits `x-amz-checksum-mode: ENABLED`, so the server returns the stored object checksum (the response-side getters already existed).

### 3. Credential provider chain
- `EnvProvider` (AWS env vars), `FileProvider` (shared AWS credentials file)
- `IamRoleProvider` (EC2 IMDSv2 with IMDSv1 fallback, plus ECS/EKS container endpoints)
- `WebIdentityProvider` (`AssumeRoleWithWebIdentity`), `AssumeRoleProvider` (SigV4-signed `AssumeRole`)
- `ChainProvider`, which falls back to anonymous credentials when no provider yields a usable pair, mirroring minio-go's `Chain`

The `Provider` trait gains an async `ensure_credentials` to prime network-backed providers; `MinioClient::ensure_credentials()` exposes priming uniformly. Secrets are redacted from `Debug` output.

## Testing
- New unit tests for header emission, request-body building, and XML/JSON parsing.
- Network providers tested **end-to-end** against an in-process mock HTTP server (IMDSv2 token flow, IMDSv1 fallback, ECS full-URI, web-identity STS, signed AssumeRole), mirroring minio-go's `httptest`-based credential tests.
- `examples/storage_class_checksum.rs` verifies storage class (`REDUCED_REDUNDANCY`) and checksum mode against a live server (defaults to play.min.io); all single-shot, multipart, and copy paths confirmed.
- `cargo test` (483 lib + 87 doc), `cargo clippy --all-targets`, and `cargo build --all-targets` are clean.

## Not covered
Real EC2 IMDS / live STS endpoint quirks and TLS still require a live environment; only request-building, parsing, and the mock-server HTTP flow are exercised in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Storage-class support for uploads, multipart flows, and object copies
  * Checksum-mode support for HEAD/GET to request checksum headers
  * New credential providers: AssumeRole, ChainProvider, EnvProvider, FileProvider, IamRoleProvider, WebIdentityProvider
  * Credential priming before requests
  * New example that validates storage-class and checksum behavior

* **Security**
  * Sensitive credential fields are redacted from debug output
<!-- end of auto-generated comment: release notes by coderabbit.ai -->