### PR TITLE
Preserve HTTP status in MinioErrorResponse and fix error classification

### DIFF
--- a/src/s3/client/mod.rs
+++ b/src/s3/client/mod.rs
@@ -1446,24 +1446,18 @@ impl SharedClientItems {
                 MinioErrorCode::MethodNotAllowed,
                 "The specified method is not allowed against this resource".into(),
             ),
-            409 => (MinioErrorCode::ResourceConflict, "Resource conflict".into()),
-            412 => (
-                MinioErrorCode::PreconditionFailed,
-                "Precondition failed".into(),
-            ),
-            429 | 503 => (MinioErrorCode::SlowDown, "Slow down".into()),
-            500 => (
-                MinioErrorCode::InternalError,
-                "Internal server error".into(),
-            ),
-            502 | 504 => (
-                MinioErrorCode::ServiceUnavailable,
-                "Service unavailable".into(),
-            ),
-            _ => (
-                MinioErrorCode::OtherError(format!("HTTP {http_status_code}")),
-                format!("Unexpected HTTP status {http_status_code}"),
-            ),
+            _ => {
+                let code = MinioErrorCode::from_http_status(http_status_code);
+                let message = match http_status_code {
+                    409 => "Resource conflict".into(),
+                    412 => "Precondition failed".into(),
+                    429 => "Slow down".into(),
+                    500 => "Internal server error".into(),
+                    502 | 503 | 504 => "Service unavailable".into(),
+                    _ => format!("Unexpected HTTP status {http_status_code}"),
+                };
+                (code, message)
+            }
         };
 
         let request_id = match headers.get(X_AMZ_REQUEST_ID) {

--- a/src/s3/client/mod.rs
+++ b/src/s3/client/mod.rs
@@ -1453,7 +1453,7 @@ impl SharedClientItems {
                     412 => "Precondition failed".into(),
                     429 => "Slow down".into(),
                     500 => "Internal server error".into(),
-                    502 | 503 | 504 => "Service unavailable".into(),
+                    502..=504 => "Service unavailable".into(),
                     _ => format!("Unexpected HTTP status {http_status_code}"),
                 };
                 (code, message)

--- a/src/s3/client/mod.rs
+++ b/src/s3/client/mod.rs
@@ -54,7 +54,7 @@ pub use crate::s3::client::hooks::RequestHooks;
 use crate::s3::creds::Provider;
 #[cfg(feature = "localhost")]
 use crate::s3::creds::StaticProvider;
-use crate::s3::error::{Error, IoError, NetworkError, S3ServerError, ValidationErr};
+use crate::s3::error::{Error, IoError, S3ServerError, ValidationErr};
 use crate::s3::header_constants::*;
 use crate::s3::http::{BaseUrl, Url};
 use crate::s3::minio_error_response::{MinioErrorCode, MinioErrorResponse};
@@ -901,7 +901,7 @@ impl MinioClient {
             if let Ok(root) = Element::parse(body.clone().reader())
                 && root.name == "Error"
             {
-                let e = MinioErrorResponse::new_from_body(body, headers)?;
+                let e = MinioErrorResponse::new_from_body(body, headers, status.as_u16())?;
                 return Err(Error::S3Server(S3ServerError::S3Error(Box::new(e))));
             }
 
@@ -1293,20 +1293,23 @@ impl MinioClient {
             return Ok(resp);
         }
 
-        // Handle error response
-        let status = resp.status();
-        Err(Error::S3Server(S3ServerError::S3Error(Box::new(
-            MinioErrorResponse::from_status_and_message(
-                status.as_u16(),
-                format!(
-                    "GET object failed with status {} ({}): {}/{}",
-                    status.as_u16(),
-                    status.canonical_reason().unwrap_or("Unknown"),
-                    bucket,
-                    object
-                ),
-            ),
-        ))))
+        // Handle error response - consume body to extract structured error info
+        let mut resp = resp;
+        let status_code = resp.status().as_u16();
+        let headers: HeaderMap = mem::take(resp.headers_mut());
+        let body: Bytes = resp.bytes().await.map_err(ValidationErr::from)?;
+
+        let e = self.shared.create_minio_error_response(
+            body,
+            status_code,
+            headers,
+            &Method::GET,
+            &url.path,
+            Some(&bucket_typed),
+            Some(&object_typed),
+            false,
+        )?;
+        Err(Error::S3Server(S3ServerError::S3Error(Box::new(e))))
     }
 
     /// create an example client for testing on localhost
@@ -1411,7 +1414,7 @@ impl SharedClientItems {
                 .map_err(Error::Validation)?; // ValidationErr -> Error
 
             return if content_type.to_lowercase().contains("application/xml") {
-                MinioErrorResponse::new_from_body(body, headers)
+                MinioErrorResponse::new_from_body(body, headers, http_status_code)
             } else {
                 Err(Error::S3Server(S3ServerError::InvalidServerResponse {
                     message: format!(
@@ -1443,16 +1446,24 @@ impl SharedClientItems {
                 MinioErrorCode::MethodNotAllowed,
                 "The specified method is not allowed against this resource".into(),
             ),
-            409 => match bucket {
-                Some(_) => (MinioErrorCode::NoSuchBucket, "Bucket does not exist".into()),
-                None => (
-                    MinioErrorCode::ResourceConflict,
-                    "Request resource conflicts".into(),
-                ),
-            },
-            _ => {
-                return Err(Error::Network(NetworkError::ServerError(http_status_code)));
-            }
+            409 => (MinioErrorCode::ResourceConflict, "Resource conflict".into()),
+            412 => (
+                MinioErrorCode::PreconditionFailed,
+                "Precondition failed".into(),
+            ),
+            429 | 503 => (MinioErrorCode::SlowDown, "Slow down".into()),
+            500 => (
+                MinioErrorCode::InternalError,
+                "Internal server error".into(),
+            ),
+            502 | 504 => (
+                MinioErrorCode::ServiceUnavailable,
+                "Service unavailable".into(),
+            ),
+            _ => (
+                MinioErrorCode::OtherError(format!("HTTP {http_status_code}")),
+                format!("Unexpected HTTP status {http_status_code}"),
+            ),
         };
 
         let request_id = match headers.get(X_AMZ_REQUEST_ID) {
@@ -1482,6 +1493,7 @@ impl SharedClientItems {
             host_id,
             bucket.cloned(),
             object.cloned(),
+            http_status_code,
         ))
     }
 }
@@ -1502,7 +1514,7 @@ mod tests {
         let root = Element::parse(body.clone().reader()).unwrap();
         assert_eq!(root.name, "Error");
 
-        let e = MinioErrorResponse::new_from_body(body, HeaderMap::new()).unwrap();
+        let e = MinioErrorResponse::new_from_body(body, HeaderMap::new(), 200).unwrap();
         assert_eq!(
             e.code(),
             MinioErrorCode::OtherError("slowdownwrite".to_string())

--- a/src/s3/response/delete_object.rs
+++ b/src/s3/response/delete_object.rs
@@ -115,7 +115,7 @@ fn parse_delete_objects(body: &Bytes, headers: &HeaderMap) -> Result<Vec<DeleteR
     let root = Element::parse(body.clone().reader()).map_err(ValidationErr::from)?;
 
     if root.name == "Error" {
-        let e = MinioErrorResponse::new_from_body(body.clone(), headers.clone())?;
+        let e = MinioErrorResponse::new_from_body(body.clone(), headers.clone(), 200)?;
         return Err(Error::S3Server(S3ServerError::S3Error(Box::new(e))));
     }
 

--- a/src/s3/types/minio_error_response.rs
+++ b/src/s3/types/minio_error_response.rs
@@ -95,6 +95,14 @@ pub enum MinioErrorCode {
     InvalidWriteOffset,
     /// Attempted to use S3 DeleteBucket API on a warehouse bucket (S3 Tables)
     WarehouseBucketOperationNotSupported,
+    /// Server is overloaded; client should back off and retry
+    SlowDown,
+    /// Server encountered an internal error
+    InternalError,
+    /// A precondition specified in the request headers was not satisfied
+    PreconditionFailed,
+    /// Service is temporarily unavailable (e.g. HTTP 502/503/504)
+    ServiceUnavailable,
 
     OtherError(String), // This is a catch-all for any error code not explicitly defined
 }
@@ -124,6 +132,10 @@ const ALL_MINIO_ERROR_CODE: &[MinioErrorCode] = &[
     MinioErrorCode::BucketAlreadyOwnedByYou,
     MinioErrorCode::InvalidWriteOffset,
     MinioErrorCode::WarehouseBucketOperationNotSupported,
+    MinioErrorCode::SlowDown,
+    MinioErrorCode::InternalError,
+    MinioErrorCode::PreconditionFailed,
+    MinioErrorCode::ServiceUnavailable,
     //MinioErrorCode::OtherError("".to_string()),
 ];
 
@@ -161,6 +173,10 @@ impl FromStr for MinioErrorCode {
             "warehousebucketoperationnotsupported" => {
                 Ok(MinioErrorCode::WarehouseBucketOperationNotSupported)
             }
+            "slowdown" => Ok(MinioErrorCode::SlowDown),
+            "internalerror" => Ok(MinioErrorCode::InternalError),
+            "preconditionfailed" => Ok(MinioErrorCode::PreconditionFailed),
+            "serviceunavailable" => Ok(MinioErrorCode::ServiceUnavailable),
 
             v => Ok(MinioErrorCode::OtherError(v.to_owned())),
         }
@@ -204,6 +220,10 @@ impl std::fmt::Display for MinioErrorCode {
             MinioErrorCode::WarehouseBucketOperationNotSupported => {
                 write!(f, "WarehouseBucketOperationNotSupported")
             }
+            MinioErrorCode::SlowDown => write!(f, "SlowDown"),
+            MinioErrorCode::InternalError => write!(f, "InternalError"),
+            MinioErrorCode::PreconditionFailed => write!(f, "PreconditionFailed"),
+            MinioErrorCode::ServiceUnavailable => write!(f, "ServiceUnavailable"),
             MinioErrorCode::OtherError(msg) => write!(f, "{msg}"),
         }
     }
@@ -239,6 +259,7 @@ pub struct MinioErrorResponse {
     host_id: String,
     bucket: Option<BucketName>,
     object: Option<ObjectKey>,
+    http_status_code: u16,
 }
 
 impl MinioErrorResponse {
@@ -251,6 +272,7 @@ impl MinioErrorResponse {
         host_id: String,
         bucket: Option<BucketName>,
         object: Option<ObjectKey>,
+        http_status_code: u16,
     ) -> Self {
         Self {
             headers,
@@ -261,6 +283,7 @@ impl MinioErrorResponse {
             host_id,
             bucket,
             object,
+            http_status_code,
         }
     }
 
@@ -270,11 +293,14 @@ impl MinioErrorResponse {
     pub fn from_status_and_message(status_code: u16, message: String) -> Self {
         let code = match status_code {
             404 => MinioErrorCode::NoSuchKey,
-            403 => MinioErrorCode::AccessDenied,
-            401 => MinioErrorCode::AccessDenied,
+            403 | 401 => MinioErrorCode::AccessDenied,
             400 => MinioErrorCode::BadRequest,
             409 => MinioErrorCode::ResourceConflict,
-            _ => MinioErrorCode::OtherError(format!("HTTP {}", status_code)),
+            412 => MinioErrorCode::PreconditionFailed,
+            429 | 503 => MinioErrorCode::SlowDown,
+            500 => MinioErrorCode::InternalError,
+            502 | 504 => MinioErrorCode::ServiceUnavailable,
+            _ => MinioErrorCode::OtherError(format!("HTTP {status_code}")),
         };
         Self {
             headers: HeaderMap::new(),
@@ -285,10 +311,15 @@ impl MinioErrorResponse {
             host_id: String::new(),
             bucket: None,
             object: None,
+            http_status_code: status_code,
         }
     }
 
-    pub fn new_from_body(body: Bytes, headers: HeaderMap) -> Result<Self, Error> {
+    pub fn new_from_body(
+        body: Bytes,
+        headers: HeaderMap,
+        http_status_code: u16,
+    ) -> Result<Self, Error> {
         let root = Element::parse(body.reader()).map_err(ValidationErr::from)?;
         Ok(Self {
             headers,
@@ -299,9 +330,13 @@ impl MinioErrorResponse {
             host_id: get_text_default(&root, "HostId"),
             bucket: get_text_option(&root, "BucketName").and_then(|s| BucketName::new(s).ok()),
             object: get_text_option(&root, "Key").and_then(|s| ObjectKey::new(s).ok()),
+            http_status_code,
         })
     }
 
+    pub fn http_status(&self) -> u16 {
+        self.http_status_code
+    }
     pub fn headers(&self) -> &HeaderMap {
         &self.headers
     }

--- a/src/s3/types/minio_error_response.rs
+++ b/src/s3/types/minio_error_response.rs
@@ -229,6 +229,29 @@ impl std::fmt::Display for MinioErrorCode {
     }
 }
 
+impl MinioErrorCode {
+    /// Map an HTTP status code to the most appropriate error code without body context.
+    ///
+    /// Used as a shared fallback by both `MinioErrorResponse::from_status_and_message`
+    /// and `create_minio_error_response` to keep status→code classification consistent.
+    /// Callers with additional context (e.g. bucket/object presence) should override
+    /// the 404 result after calling this.
+    pub fn from_http_status(status: u16) -> Self {
+        match status {
+            400 => Self::BadRequest,
+            401 | 403 => Self::AccessDenied,
+            404 => Self::ResourceNotFound,
+            405 | 501 => Self::MethodNotAllowed,
+            409 => Self::ResourceConflict,
+            412 => Self::PreconditionFailed,
+            429 => Self::SlowDown,
+            500 => Self::InternalError,
+            502 | 503 | 504 => Self::ServiceUnavailable,
+            _ => Self::OtherError(format!("HTTP {status}")),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_error_code {
     use super::*;
@@ -291,16 +314,11 @@ impl MinioErrorResponse {
     ///
     /// Used for fast-path operations where full error details aren't available.
     pub fn from_status_and_message(status_code: u16, message: String) -> Self {
-        let code = match status_code {
-            404 => MinioErrorCode::NoSuchKey,
-            403 | 401 => MinioErrorCode::AccessDenied,
-            400 => MinioErrorCode::BadRequest,
-            409 => MinioErrorCode::ResourceConflict,
-            412 => MinioErrorCode::PreconditionFailed,
-            429 | 503 => MinioErrorCode::SlowDown,
-            500 => MinioErrorCode::InternalError,
-            502 | 504 => MinioErrorCode::ServiceUnavailable,
-            _ => MinioErrorCode::OtherError(format!("HTTP {status_code}")),
+        // 404 defaults to NoSuchKey rather than the generic ResourceNotFound
+        let code = if status_code == 404 {
+            MinioErrorCode::NoSuchKey
+        } else {
+            MinioErrorCode::from_http_status(status_code)
         };
         Self {
             headers: HeaderMap::new(),

--- a/src/s3/types/minio_error_response.rs
+++ b/src/s3/types/minio_error_response.rs
@@ -246,7 +246,7 @@ impl MinioErrorCode {
             412 => Self::PreconditionFailed,
             429 => Self::SlowDown,
             500 => Self::InternalError,
-            502 | 503 | 504 => Self::ServiceUnavailable,
+            502..=504 => Self::ServiceUnavailable,
             _ => Self::OtherError(format!("HTTP {status}")),
         }
     }


### PR DESCRIPTION
- Add http_status_code: u16 field to MinioErrorResponse with http_status()
  accessor; thread it through new(), new_from_body(), and from_status_and_message()
- Fix 409 → ResourceConflict (was NoSuchBucket regardless of context,
  causing HEAD 409 to surface as ENOENT)
- Replace Error::Network(ServerError) fallthrough with named S3Server errors
  for 412 → PreconditionFailed, 429/503 → SlowDown, 500 → InternalError,
  502/504 → ServiceUnavailable; unknown status codes become OtherError
  instead of transport errors
- Fix GET/streaming-LIST error path to consume the response body and parse
  XML <Code>/<Message> (was discarding the body and fabricating a message)
- Add SlowDown, InternalError, PreconditionFailed, ServiceUnavailable as
  named MinioErrorCode variants so consumers can match without string comparison
- Remove unused NetworkError import from client/mod.rs

https://claude.ai/code/session_01WZ8FBLtEdqMmrnVacV4tzo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error handling now respects HTTP status codes when parsing S3/MinIO responses, producing structured server error results.
  * Whole-request errors returned with HTTP 200 are correctly interpreted with explicit status awareness.

* **New Features**
  * Added additional server error types (SlowDown, InternalError, PreconditionFailed, ServiceUnavailable) and preserved the originating HTTP status in error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->