### PR TITLE
Preserve original casing of unrecognized error codes in OtherError

### DIFF
--- a/src/s3/client/mod.rs
+++ b/src/s3/client/mod.rs
@@ -1511,7 +1511,7 @@ mod tests {
         let e = MinioErrorResponse::new_from_body(body, HeaderMap::new(), 200).unwrap();
         assert_eq!(
             e.code(),
-            MinioErrorCode::OtherError("slowdownwrite".to_string())
+            MinioErrorCode::OtherError("SlowDownWrite".to_string())
         );
     }
 

--- a/src/s3/types/minio_error_response.rs
+++ b/src/s3/types/minio_error_response.rs
@@ -178,7 +178,7 @@ impl FromStr for MinioErrorCode {
             "preconditionfailed" => Ok(MinioErrorCode::PreconditionFailed),
             "serviceunavailable" => Ok(MinioErrorCode::ServiceUnavailable),
 
-            v => Ok(MinioErrorCode::OtherError(v.to_owned())),
+            _ => Ok(MinioErrorCode::OtherError(s.to_owned())),
         }
     }
 }


### PR DESCRIPTION
FromStr for MinioErrorCode matched on s.to_lowercase() for
case-insensitive comparison, then stored the already-lowercased
binding v in OtherError. Callers (e.g. minfs) received
OtherError("notarealerror") instead of OtherError("NotARealError")
and could not recover the original string.

Fix: store s (the original input) in the catch-all arm instead of v.
Known variants continue to match case-insensitively; unknown codes
are stored verbatim as the server sent them.

Update the existing test assertion to reflect the corrected behaviour
(SlowDownWrite, not slowdownwrite).

https://claude.ai/code/session_01WZ8FBLtEdqMmrnVacV4tzo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error code handling in S3 responses to properly preserve casing and unknown error codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->