### PR TITLE
feat: expose MinIO AccessTime on ListEntry

### DIFF
--- a/src/s3/response/list_objects.rs
+++ b/src/s3/response/list_objects.rs
@@ -129,6 +129,11 @@ fn parse_list_objects_contents(
             .transpose()?;
         let is_delete_marker = content.name() == "DeleteMarker";
         let checksum_algorithm = content.get_child_text("ChecksumAlgorithm");
+        let access_time = content
+            .get_child("Internal")
+            .and_then(|internal| internal.get_child_text("AccessTime"))
+            .map(|s| from_iso8601utc(&s))
+            .transpose()?;
 
         contents.push(ListEntry {
             name: key,
@@ -146,6 +151,7 @@ fn parse_list_objects_contents(
             is_delete_marker,
             encoding_type: etype,
             checksum_algorithm,
+            access_time,
         });
     }
 
@@ -178,6 +184,7 @@ fn parse_list_objects_common_prefixes(
             is_delete_marker: false,
             encoding_type: encoding_type.as_ref().cloned(),
             checksum_algorithm: None,
+            access_time: None,
         });
     }
 
@@ -539,5 +546,37 @@ mod tests {
         let contents = parse_contents(xml);
         assert_eq!(contents.len(), 1);
         assert_eq!(contents[0].checksum_algorithm, None);
+    }
+
+    #[test]
+    fn parses_access_time_from_internal() {
+        let xml = r#"<ListBucketResult>
+            <Contents>
+                <Key>obj</Key>
+                <LastModified>2024-01-01T00:00:00.000Z</LastModified>
+                <Internal>
+                    <AccessTime>2024-01-15T12:45:30Z</AccessTime>
+                </Internal>
+            </Contents>
+        </ListBucketResult>"#;
+        let contents = parse_contents(xml);
+        assert_eq!(contents.len(), 1);
+        assert_eq!(
+            contents[0].access_time,
+            Some(from_iso8601utc("2024-01-15T12:45:30Z").unwrap())
+        );
+    }
+
+    #[test]
+    fn access_time_absent_is_none() {
+        let xml = r#"<ListBucketResult>
+            <Contents>
+                <Key>obj</Key>
+                <LastModified>2024-01-01T00:00:00.000Z</LastModified>
+            </Contents>
+        </ListBucketResult>"#;
+        let contents = parse_contents(xml);
+        assert_eq!(contents.len(), 1);
+        assert_eq!(contents[0].access_time, None);
     }
 }

--- a/src/s3/types/basic_types.rs
+++ b/src/s3/types/basic_types.rs
@@ -39,6 +39,9 @@ pub struct ListEntry {
     pub is_delete_marker: bool,
     pub encoding_type: Option<String>,
     pub checksum_algorithm: Option<String>,
+    /// MinIO `<Internal><AccessTime>` (ListObjectsV2 with `metadata=true` on a
+    /// server started with `--lazy-access-time`). `None` on plain S3 or when not tracked.
+    pub access_time: Option<UtcTime>,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## What

Adds an optional `access_time: Option<UtcTime>` field to `ListEntry`.

When `ListObjectsV2` is called with `metadata=true` against a MinIO/AIStor server started with `--lazy-access-time`, each object's `<Contents>` includes an `<Internal><AccessTime>` element. This change parses it into `ListEntry.access_time` using the existing `from_iso8601utc` helper. It is `None` on plain S3 or when access-time tracking is not enabled.

## Changes

- `src/s3/types/basic_types.rs` — add `access_time` field to `ListEntry`.
- `src/s3/response/list_objects.rs` — parse `<Internal><AccessTime>` in `parse_list_objects_contents`; set `None` in the common-prefixes constructor.
- Tests: `parses_access_time_from_internal` and `access_time_absent_is_none`.

## Notes

`from_iso8601utc` handles the `...Z` and `...S.mmmZ` forms MinIO emits. If a live server emits nanosecond precision or a non-`Z` offset for `<AccessTime>`, the parser would need an additional pattern.

## Verification

- `cargo test --lib list_objects` — 13 passed, 0 failed
- `cargo clippy --all-targets` — zero warnings
- `cargo fmt --all --check` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * S3 list objects operations now retrieve and include access time metadata when available from the server.

* **Tests**
  * Added test coverage for access time field presence and absence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->