### PR TITLE
feat: recursive prefix rename (x-amz-rename-recursive)

### DIFF
--- a/src/s3/builders/rename_object.rs
+++ b/src/s3/builders/rename_object.rs
@@ -122,14 +122,15 @@ fn conditional_etag_value(etag: &str) -> String {
     }
 }
 
-/// Builds the `x-amz-rename-source` header value as `/{bucket}/{object}`, percent-encoding
-/// the object key (preserving `/`) the same way minio-go encodes `x-amz-copy-source`.
-/// The server decodes it via `url.Parse().Path`, so the key must be encoded here.
-fn rename_source_value(bucket: &str, src_object: &str) -> String {
+/// Builds the `x-amz-rename-source` header value as `/{object}` — the source
+/// **key only**, with no bucket qualifier. AIStor addresses the rename source by
+/// key within the request bucket (same-bucket rename); the whole header value is
+/// the key and any slashes are key prefixes. The server decodes it via
+/// `url.Parse().Path` then `trimLeadingSlash`, so the key is percent-encoded here
+/// (preserving `/`) and prefixed with a single leading slash.
+fn rename_source_value(src_object: &str) -> String {
     let encoded = urlencode_object_key(src_object);
-    let mut value = String::with_capacity(bucket.len() + encoded.len() + 2);
-    value.push('/');
-    value.push_str(bucket);
+    let mut value = String::with_capacity(encoded.len() + 1);
     value.push('/');
     value.push_str(&encoded);
     value
@@ -171,7 +172,7 @@ impl ToS3Request for RenameObject {
 
         headers.add(
             X_AMZ_RENAME_SOURCE,
-            rename_source_value(self.bucket.as_str(), self.src_object.as_str()),
+            rename_source_value(self.src_object.as_str()),
         );
 
         if let Some(etag) = &self.src_match_etag {
@@ -226,18 +227,13 @@ mod tests {
 
     #[test]
     fn rename_source_value_format() {
-        assert_eq!(
-            rename_source_value("my-bucket", "src/object.txt"),
-            "/my-bucket/src/object.txt"
-        );
+        // Key only, no bucket qualifier.
+        assert_eq!(rename_source_value("src/object.txt"), "/src/object.txt");
     }
 
     #[test]
     fn rename_source_value_url_encodes_object() {
-        assert_eq!(
-            rename_source_value("my-bucket", "a b+c?d"),
-            "/my-bucket/a%20b%2Bc%3Fd"
-        );
+        assert_eq!(rename_source_value("a b+c?d"), "/a%20b%2Bc%3Fd");
     }
 
     #[test]

--- a/src/s3/builders/rename_object.rs
+++ b/src/s3/builders/rename_object.rs
@@ -80,6 +80,12 @@ pub struct RenameObject {
     /// `If-Unmodified-Since` on the destination (HTTP-date), sent verbatim.
     #[builder(default, setter(into))]
     dst_unmodified_since: Option<String>,
+    /// `x-amz-rename-recursive` (MinIO extension). When `true`, the rename is a
+    /// recursive prefix rename: every object under the source directory prefix
+    /// is moved into the destination prefix in one server-side request. Both
+    /// `src_object` and `dst_object` must be directory prefixes (trailing `/`).
+    #[builder(default)]
+    recursive: bool,
 }
 
 /// Builder type for [`RenameObject`] that is returned by [`MinioClient::rename_object`](crate::s3::client::MinioClient::rename_object).
@@ -93,6 +99,7 @@ pub type RenameObjectBldr = RenameObjectBuilder<(
     (BucketName,),
     (ObjectKey,),
     (ObjectKey,),
+    (),
     (),
     (),
     (),
@@ -194,6 +201,10 @@ impl ToS3Request for RenameObject {
         }
         if let Some(v) = self.dst_unmodified_since {
             headers.add(IF_UNMODIFIED_SINCE, v);
+        }
+
+        if self.recursive {
+            headers.add(X_AMZ_RENAME_RECURSIVE, "true");
         }
 
         Ok(S3Request::builder()

--- a/src/s3/client/mod.rs
+++ b/src/s3/client/mod.rs
@@ -1546,6 +1546,11 @@ mod tests {
         );
         let root = Element::parse(body.clone().reader()).unwrap();
         assert_eq!(root.name, "Error");
+
+        // The same body must also parse into a structured error (this is what
+        // the 200-with-error path returns to the caller).
+        let e = MinioErrorResponse::new_from_body(body, HeaderMap::new(), 200).unwrap();
+        assert_eq!(e.code(), MinioErrorCode::InternalError);
     }
 
     #[test]
@@ -1556,7 +1561,7 @@ mod tests {
 <RenamePrefixResult><Moved>3</Moved></RenamePrefixResult>",
         );
         let root = Element::parse(body.clone().reader()).unwrap();
-        assert_ne!(root.name, "Error");
+        assert_eq!(root.name, "RenamePrefixResult");
     }
 
     #[test]

--- a/src/s3/client/mod.rs
+++ b/src/s3/client/mod.rs
@@ -1534,6 +1534,32 @@ mod tests {
     }
 
     #[test]
+    fn test_200_ok_whitespaced_keepalive_error_is_recognized() {
+        // AIStor keep-alive (CompleteMultipartUpload / RenamePrefix) writes the
+        // XML declaration first, then streams whitespace while the operation
+        // runs, then the final body. On a slow rename that rolls back, the body
+        // is `<?xml?>` + keep-alive spaces + `<Error>`. The 200-with-error path
+        // must still recognise it.
+        let body = Bytes::from_static(
+            b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n          \
+<Error><Code>InternalError</Code><Message>rename rolled back</Message></Error>",
+        );
+        let root = Element::parse(body.clone().reader()).unwrap();
+        assert_eq!(root.name, "Error");
+    }
+
+    #[test]
+    fn test_200_ok_whitespaced_keepalive_success_is_not_error() {
+        // The success counterpart: `<?xml?>` + spaces + `<RenamePrefixResult>`.
+        let body = Bytes::from_static(
+            b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n          \
+<RenamePrefixResult><Moved>3</Moved></RenamePrefixResult>",
+        );
+        let root = Element::parse(body.clone().reader()).unwrap();
+        assert_ne!(root.name, "Error");
+    }
+
+    #[test]
     fn test_200_ok_normal_body_is_not_error() {
         let body = Bytes::from_static(
             br#"<?xml version="1.0" encoding="UTF-8"?>

--- a/src/s3/types/header_constants.rs
+++ b/src/s3/types/header_constants.rs
@@ -154,6 +154,8 @@ pub const X_AMZ_RENAME_SOURCE_IF_MODIFIED_SINCE: &str = "x-amz-rename-source-if-
 
 pub const X_AMZ_RENAME_SOURCE_IF_UNMODIFIED_SINCE: &str = "x-amz-rename-source-if-unmodified-since";
 
+pub const X_AMZ_RENAME_RECURSIVE: &str = "x-amz-rename-recursive";
+
 pub const X_AMZ_TRAILER: &str = "X-Amz-Trailer";
 
 pub const X_AMZ_DECODED_CONTENT_LENGTH: &str = "X-Amz-Decoded-Content-Length";

--- a/tests/s3/rename_object.rs
+++ b/tests/s3/rename_object.rs
@@ -144,6 +144,9 @@ async fn rename_prefix(ctx: TestContext, bucket: BucketName) {
             .send()
             .await
             .is_err();
-        assert!(src_gone, "source child {child} should be gone after recursive rename");
+        assert!(
+            src_gone,
+            "source child {child} should be gone after recursive rename"
+        );
     }
 }

--- a/tests/s3/rename_object.rs
+++ b/tests/s3/rename_object.rs
@@ -82,3 +82,68 @@ async fn rename_object(ctx: TestContext, bucket: BucketName) {
         "source object should no longer exist after rename"
     );
 }
+
+/// Recursive prefix rename (MinIO/AIStor extension): `x-amz-rename-recursive: true`
+/// renames every object under the source directory prefix into the destination
+/// prefix in one server-side request. Source and destination are directory
+/// prefixes (trailing `/`); afterwards every child exists under the destination
+/// and none remain under the source.
+#[minio_macros::test]
+async fn rename_prefix(ctx: TestContext, bucket: BucketName) {
+    let base = rand_object_name();
+    let src_prefix = format!("{base}-src/");
+    let dst_prefix = format!("{base}-dst/");
+    let children = ["a.bin", "nested/b.bin", "nested/deep/c.bin"];
+    let size = 16_u64;
+
+    for child in children {
+        let resp: PutObjectContentResponse = ctx
+            .client
+            .put_object_content(
+                &bucket,
+                format!("{src_prefix}{child}"),
+                ObjectContent::new_from_stream(RandSrc::new(size), Some(size)),
+            )
+            .unwrap()
+            .build()
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.object_size(), size);
+    }
+
+    let resp: RenameObjectResponse = ctx
+        .client
+        .rename_object(&bucket, &src_prefix, &dst_prefix)
+        .unwrap()
+        .recursive(true)
+        .build()
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.bucket(), Some(&bucket));
+
+    for child in children {
+        // Every child now exists under the destination prefix...
+        let moved: StatObjectResponse = ctx
+            .client
+            .stat_object(&bucket, format!("{dst_prefix}{child}"))
+            .unwrap()
+            .build()
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(moved.size().unwrap(), size);
+
+        // ...and is gone from the source prefix.
+        let src_gone = ctx
+            .client
+            .stat_object(&bucket, format!("{src_prefix}{child}"))
+            .unwrap()
+            .build()
+            .send()
+            .await
+            .is_err();
+        assert!(src_gone, "source child {child} should be gone after recursive rename");
+    }
+}

--- a/tests/start-server.sh
+++ b/tests/start-server.sh
@@ -17,6 +17,9 @@ cp ./tests/public.crt ./tests/private.key /tmp/certs/
 
 # Free-tier AIStor license so the server exposes AIStor APIs (QoS, Inventory,
 # RenameObject, UpdateObjectEncryption, LDAP STS) that the integration tests cover.
+# Disable command tracing around the license + docker run so the credential is
+# not echoed into CI logs.
+set +x
 MINIO_LICENSE="eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJhaWQiOjAsImNhcCI6MCwiaWF0IjoxLjc4MDAzMTY0NTUyMzA5ODM1OGU5LCJpc3MiOiJzdWJuZXRAbWluLmlvIiwibGlkIjoiYjNhYTliNGQtOTUxYy00MjIzLTgyMmEtZGY2NjE5MDNjOWFkIiwibm9kZXMiOjEsIm9yZyI6IiIsInBsYW4iOiJGUkVFIiwicHJvZHVjdCI6IkFJU3RvciIsInN1YiI6ImRldkBtaW5pby5pbyIsInRyaWFsIjpmYWxzZX0.Aq0kaFgd5SMHYEK7fIYzPsU4xlS119sj-BSyftCDpmtHIbW6KNFXGA9nbKPc17ZXKgcQgUoaPncsq30EOy7PyH-lp3LPpy3rPoD7ptJHI2v0jqpvlnP0cVGK0Yuw3vib"
 
 # Serve HTTPS on :9000 with the test certs the integration suite trusts via
@@ -32,5 +35,14 @@ docker run -d --name minio-test \
     -e MINIO_NOTIFY_WEBHOOK_ENDPOINT_miniojavatest=http://example.org/ \
     "${MINIO_IMAGE}" \
     server /tmp/test-xl/{1...4}/ --certs-dir /certs/
+set -x
 
-sleep 10
+# Wait until the server is actually ready rather than sleeping a fixed time, so
+# slow/fast container startup does not make CI flaky.
+for _ in $(seq 1 60); do
+    if curl --silent --show-error --fail --cacert ./tests/public.crt \
+        https://localhost:9000/minio/health/ready >/dev/null; then
+        break
+    fi
+    sleep 1
+done

--- a/tests/start-server.sh
+++ b/tests/start-server.sh
@@ -39,10 +39,18 @@ set -x
 
 # Wait until the server is actually ready rather than sleeping a fixed time, so
 # slow/fast container startup does not make CI flaky.
+ready=0
 for _ in $(seq 1 60); do
     if curl --silent --show-error --fail --cacert ./tests/public.crt \
         https://localhost:9000/minio/health/ready >/dev/null; then
+        ready=1
         break
     fi
     sleep 1
 done
+
+if [ "${ready}" -ne 1 ]; then
+    echo "MinIO did not become ready within 60 seconds" >&2
+    docker logs minio-test >&2 || true
+    exit 1
+fi

--- a/tests/start-server.sh
+++ b/tests/start-server.sh
@@ -3,11 +3,14 @@
 set -x
 set -e
 
-wget --quiet https://dl.min.io/aistor/minio/edge/linux-amd64/minio
-chmod +x minio
+# Always test against the AIStor :edge image, which carries the latest AIStor
+# extensions the integration tests exercise (RenameObject/RenamePrefix,
+# UpdateObjectEncryption, QoS, Inventory, LDAP STS).
+MINIO_IMAGE="registry.min.dev/aistor/minio:edge"
+docker pull "${MINIO_IMAGE}"
 
 echo "MinIO Server Version:"
-./minio --version
+docker run --rm "${MINIO_IMAGE}" --version
 
 mkdir -p /tmp/certs
 cp ./tests/public.crt ./tests/private.key /tmp/certs/
@@ -16,14 +19,18 @@ cp ./tests/public.crt ./tests/private.key /tmp/certs/
 # RenameObject, UpdateObjectEncryption, LDAP STS) that the integration tests cover.
 MINIO_LICENSE="eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJhaWQiOjAsImNhcCI6MCwiaWF0IjoxLjc4MDAzMTY0NTUyMzA5ODM1OGU5LCJpc3MiOiJzdWJuZXRAbWluLmlvIiwibGlkIjoiYjNhYTliNGQtOTUxYy00MjIzLTgyMmEtZGY2NjE5MDNjOWFkIiwibm9kZXMiOjEsIm9yZyI6IiIsInBsYW4iOiJGUkVFIiwicHJvZHVjdCI6IkFJU3RvciIsInN1YiI6ImRldkBtaW5pby5pbyIsInRyaWFsIjpmYWxzZX0.Aq0kaFgd5SMHYEK7fIYzPsU4xlS119sj-BSyftCDpmtHIbW6KNFXGA9nbKPc17ZXKgcQgUoaPncsq30EOy7PyH-lp3LPpy3rPoD7ptJHI2v0jqpvlnP0cVGK0Yuw3vib"
 
-(MINIO_CI_CD=true \
-    MINIO_SITE_REGION=us-east-1 \
-    MINIO_LICENSE="${MINIO_LICENSE}" \
-    MINIO_NOTIFY_WEBHOOK_ENABLE_miniojavatest=on \
-    MINIO_NOTIFY_WEBHOOK_ENDPOINT_miniojavatest=http://example.org/ \
-    ./minio server /tmp/test-xl/{1...4}/ --certs-dir /tmp/certs/ &)
+# Serve HTTPS on :9000 with the test certs the integration suite trusts via
+# MINIO_SSL_CERT_FILE=./tests/public.crt.
+docker rm -f minio-test >/dev/null 2>&1 || true
+docker run -d --name minio-test \
+    -p 9000:9000 \
+    -v /tmp/certs:/certs \
+    -e MINIO_CI_CD=true \
+    -e MINIO_SITE_REGION=us-east-1 \
+    -e MINIO_LICENSE="${MINIO_LICENSE}" \
+    -e MINIO_NOTIFY_WEBHOOK_ENABLE_miniojavatest=on \
+    -e MINIO_NOTIFY_WEBHOOK_ENDPOINT_miniojavatest=http://example.org/ \
+    "${MINIO_IMAGE}" \
+    server /tmp/test-xl/{1...4}/ --certs-dir /certs/
 
 sleep 10
-
-
-


### PR DESCRIPTION
## What

Add a native `recursive` flag to the `RenameObject` builder. When set it emits the `x-amz-rename-recursive: true` header, turning the request into the MinIO/AIStor **recursive prefix rename** (`RenamePrefix`): every object under the source directory prefix is moved into the destination prefix in one server-side request.

Source and destination must be directory prefixes (trailing `/`), already validated by `validate_rename` (which also rejects directory/object-suffix mismatch and prefix nesting).

## Why

minfs (the POSIX FUSE mount over AIStor) needs server-side directory rename — re-keying every object client-side is O(n) round-trips. The server-side `RenamePrefix` collapses it into one journaled, all-or-nothing request. This is the client-side half.

## Notes on the slow-rename / rollback wire contract

A recursive rename of many or large objects can take time, so AIStor keeps the connection alive with whitespace (the `CompleteMultipartUpload` pattern): it sends `200 OK` + the `<?xml?>` header, streams spaces while it works, then writes the final body — which on a rollback is a root `<Error>` element **under the 200**. The builder already opts into `expect_200_ok_with_error(true)`, so `execute_internal` reads the full body and surfaces that `<Error>` as a server error. Added unit tests for the exact `<?xml?>` + keep-alive-whitespace + `<Error>` / `<RenamePrefixResult>` layouts.

## Changes

- `RenameObject` builder: `recursive` field (+ tuple-alias slot) emitting `x-amz-rename-recursive`.
- `X_AMZ_RENAME_RECURSIVE` header constant.
- `rename_prefix` integration test (puts a small tree, renames recursively, asserts every child moved and the source prefix is empty).
- Test harness (`tests/start-server.sh`) now runs the `registry.min.dev/aistor/minio:edge` docker image (carries `RenamePrefix`) instead of downloading the binary.

## Test plan

- `cargo test --lib rename` — builder + 200-with-error parse unit tests pass.
- `rename_prefix` integration test runs against the `:edge` server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for recursive S3 rename operations on object prefixes.

* **Bug Fixes**
  * Adjusted rename request headers to use key-only source formatting for rename operations.

* **Tests**
  * Added an integration test covering recursive prefix renames.
  * Added unit tests to verify correct handling of “200 OK with error body” XML parsing edge cases.

* **Chores / Infrastructure**
  * Updated the MinIO test server setup to run via Docker with readiness polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->