### PR TITLE
feat(signer): expose public SigV4 request-signing helpers

### DIFF
--- a/src/s3/signer.rs
+++ b/src/s3/signer.rs
@@ -381,6 +381,41 @@ pub fn sign_v4_s3_request(
     payload_sha256: &str,
     date: UtcTime,
 ) -> Multimap {
+    sign_v4_service_request(
+        "s3",
+        method,
+        host,
+        path,
+        region,
+        query_params,
+        extra_headers,
+        access_key,
+        secret_key,
+        session_token,
+        payload_sha256,
+        date,
+    )
+}
+
+/// Like [`sign_v4_s3_request`] but signs for an arbitrary `service` type (e.g.
+/// `"s3tables"` for the Iceberg REST catalog, or `"sts"` for STS actions). The
+/// `service` becomes part of the credential scope
+/// (`.../<region>/<service>/aws4_request`).
+#[allow(clippy::too_many_arguments)]
+pub fn sign_v4_service_request(
+    service: &str,
+    method: &Method,
+    host: &str,
+    path: &str,
+    region: &str,
+    query_params: &Multimap,
+    extra_headers: &Multimap,
+    access_key: &str,
+    secret_key: &str,
+    session_token: Option<&str>,
+    payload_sha256: &str,
+    date: UtcTime,
+) -> Multimap {
     let mut headers = extra_headers.clone();
     headers.add(HOST, host);
     headers.add(X_AMZ_DATE, to_amz_date(date));
@@ -391,8 +426,9 @@ pub fn sign_v4_s3_request(
 
     let cache = RwLock::new(SigningKeyCache::new());
     let region = Region::new(region.to_owned()).unwrap_or_default();
-    sign_v4_s3(
+    sign_v4_with_service_type(
         &cache,
+        service,
         method,
         path,
         &region,

--- a/src/s3/signer.rs
+++ b/src/s3/signer.rs
@@ -347,99 +347,98 @@ pub(crate) fn sign_v4_s3(
     )
 }
 
-/// Signs an arbitrary HTTP request with AWS Signature V4 as service `"s3"` and
-/// returns the complete set of headers to send with it.
+/// Parameters for signing a single request with [`RequestSigner::sign`].
 ///
-/// This is a self-contained entry point for signing requests to non-object S3
-/// APIs served on the same endpoint (for example the AIStor Memory API under
-/// `/_mem/v1`). Unlike [`sign_v4_s3`], it owns its signing-key cache and adds
-/// the mandatory `host`, `x-amz-date`, `x-amz-content-sha256` and (when a
-/// session token is supplied) `x-amz-security-token` headers before signing, so
-/// callers outside the SDK do not have to replicate the SDK's header prep.
-///
-/// - `method` / `path`: the request line; `path` is the URL-encoded path only.
-/// - `host`: the value for the `Host` header (e.g. `localhost:9000`).
-/// - `region`: the SigV4 credential-scope region.
-/// - `query_params`: canonicalized into the signature (may be empty).
-/// - `extra_headers`: additional headers to fold into the signature (e.g.
-///   `content-type`, `content-length`); may be empty.
-/// - `payload_sha256`: lowercase-hex SHA-256 of the request body. Use
-///   [`crate::s3::utils::EMPTY_SHA256`] for an empty body.
-///
-/// The returned [`Multimap`] contains every header (including the signed ones
-/// and the `Authorization` header) that must accompany the request.
-pub fn sign_v4_s3_request(
-    method: &Method,
-    host: &str,
-    path: &str,
-    region: &str,
-    query_params: &Multimap,
-    extra_headers: &Multimap,
-    access_key: &str,
-    secret_key: &str,
-    session_token: Option<&str>,
-    payload_sha256: &str,
-    date: UtcTime,
-) -> Multimap {
-    sign_v4_service_request(
-        "s3",
-        method,
-        host,
-        path,
-        region,
-        query_params,
-        extra_headers,
-        access_key,
-        secret_key,
-        session_token,
-        payload_sha256,
-        date,
-    )
+/// Consolidates the request fields into one struct rather than a long argument
+/// list. `extra_headers` is taken by value: the signer mutates it in place
+/// (adding the signed headers) and returns it, so callers pass owned headers and
+/// avoid an internal clone.
+pub struct SignRequestOptions<'a> {
+    /// SigV4 service for the credential scope: `"s3"` (Memory API), `"s3tables"`
+    /// (Iceberg REST catalog), `"sts"`, etc.
+    pub service: &'a str,
+    /// HTTP method.
+    pub method: &'a Method,
+    /// Value for the `Host` header (e.g. `localhost:9000`).
+    pub host: &'a str,
+    /// URL-encoded request path only.
+    pub path: &'a str,
+    /// SigV4 credential-scope region.
+    pub region: &'a str,
+    /// Query parameters canonicalized into the signature (may be empty).
+    pub query_params: &'a Multimap,
+    /// Additional headers to fold into the signature (e.g. `content-type`,
+    /// `content-length`); may be empty. Consumed and returned with the signed
+    /// headers added.
+    pub extra_headers: Multimap,
+    /// Access key id.
+    pub access_key: &'a str,
+    /// Secret access key.
+    pub secret_key: &'a str,
+    /// Optional session token (STS temporary credentials).
+    pub session_token: Option<&'a str>,
+    /// Lowercase-hex SHA-256 of the request body. Use
+    /// [`crate::s3::utils::EMPTY_SHA256`] for an empty body.
+    pub payload_sha256: &'a str,
+    /// Request timestamp.
+    pub date: UtcTime,
 }
 
-/// Like [`sign_v4_s3_request`] but signs for an arbitrary `service` type (e.g.
-/// `"s3tables"` for the Iceberg REST catalog, or `"sts"` for STS actions). The
-/// `service` becomes part of the credential scope
-/// (`.../<region>/<service>/aws4_request`).
-#[allow(clippy::too_many_arguments)]
-pub fn sign_v4_service_request(
-    service: &str,
-    method: &Method,
-    host: &str,
-    path: &str,
-    region: &str,
-    query_params: &Multimap,
-    extra_headers: &Multimap,
-    access_key: &str,
-    secret_key: &str,
-    session_token: Option<&str>,
-    payload_sha256: &str,
-    date: UtcTime,
-) -> Multimap {
-    let mut headers = extra_headers.clone();
-    headers.add(HOST, host);
-    headers.add(X_AMZ_DATE, to_amz_date(date));
-    headers.add(X_AMZ_CONTENT_SHA256, payload_sha256);
-    if let Some(token) = session_token {
-        headers.add(X_AMZ_SECURITY_TOKEN, token);
+/// A reusable SigV4 request signer for non-object S3 APIs served on the same
+/// endpoint — for example the AIStor Memory API (`/_mem/v1`), the Tables/Iceberg
+/// REST catalog (`/_iceberg/v1`, service `s3tables`), or STS.
+///
+/// Holds a signing-key cache that is **reused across calls**, so a caller that
+/// signs many requests (e.g. one signer per API client) amortizes the HMAC-SHA256
+/// key derivation. Construct one and keep it for the lifetime of the client.
+///
+/// [`sign`](RequestSigner::sign) adds the mandatory `host`, `x-amz-date`,
+/// `x-amz-content-sha256` and (when a session token is supplied)
+/// `x-amz-security-token` headers before signing, so callers outside the SDK do
+/// not replicate the SDK's header prep.
+#[derive(Debug, Default)]
+pub struct RequestSigner {
+    cache: RwLock<SigningKeyCache>,
+}
+
+impl RequestSigner {
+    /// Create a signer with a fresh signing-key cache.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            cache: RwLock::new(SigningKeyCache::new()),
+        }
     }
 
-    let cache = RwLock::new(SigningKeyCache::new());
-    let region = Region::new(region.to_owned()).unwrap_or_default();
-    sign_v4_with_service_type(
-        &cache,
-        service,
-        method,
-        path,
-        &region,
-        &mut headers,
-        query_params,
-        access_key,
-        secret_key,
-        payload_sha256,
-        date,
-    );
-    headers
+    /// Sign a request and return every header (including the signed ones and the
+    /// `Authorization` header) that must accompany it. Reuses this signer's
+    /// signing-key cache.
+    #[must_use]
+    pub fn sign(&self, opts: SignRequestOptions<'_>) -> Multimap {
+        let mut headers = opts.extra_headers;
+        headers.add(HOST, opts.host);
+        headers.add(X_AMZ_DATE, to_amz_date(opts.date));
+        headers.add(X_AMZ_CONTENT_SHA256, opts.payload_sha256);
+        if let Some(token) = opts.session_token {
+            headers.add(X_AMZ_SECURITY_TOKEN, token);
+        }
+
+        let region = Region::new(opts.region.to_owned()).unwrap_or_default();
+        sign_v4_with_service_type(
+            &self.cache,
+            opts.service,
+            opts.method,
+            opts.path,
+            &region,
+            &mut headers,
+            opts.query_params,
+            opts.access_key,
+            opts.secret_key,
+            opts.payload_sha256,
+            opts.date,
+        );
+        headers
+    }
 }
 
 /// Signs and updates headers for the given request using a custom service type.
@@ -760,7 +759,9 @@ pub(crate) fn sign_v4_with_service_type_and_context(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::s3::header_constants::{HOST, X_AMZ_CONTENT_SHA256, X_AMZ_DATE};
+    use crate::s3::header_constants::{
+        HOST, X_AMZ_CONTENT_SHA256, X_AMZ_DATE, X_AMZ_SECURITY_TOKEN,
+    };
     use crate::s3::multimap_ext::{Multimap, MultimapExt};
     use chrono::{TimeZone, Utc};
     use hyper::http::Method;
@@ -1593,5 +1594,133 @@ mod tests {
         assert_eq!(context.date_time, cloned.date_time);
         assert_eq!(context.scope, cloned.scope);
         assert_eq!(context.seed_signature, cloned.seed_signature);
+    }
+
+    // ===========================
+    // RequestSigner Tests (Public API)
+    // ===========================
+
+    const TEST_ACCESS_KEY: &str = "AKIAIOSFODNN7EXAMPLE";
+    const TEST_SECRET_KEY: &str = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+    const TEST_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    fn base_opts<'a>(service: &'a str, extra_headers: Multimap) -> SignRequestOptions<'a> {
+        SignRequestOptions {
+            service,
+            method: &Method::GET,
+            host: "localhost:9000",
+            path: "/_mem/v1/cortexes",
+            region: "us-east-1",
+            query_params: EMPTY_QUERY.get_or_init(Multimap::new),
+            extra_headers,
+            access_key: TEST_ACCESS_KEY,
+            secret_key: TEST_SECRET_KEY,
+            session_token: None,
+            payload_sha256: TEST_SHA256,
+            date: get_test_date(),
+        }
+    }
+
+    use std::sync::OnceLock;
+    static EMPTY_QUERY: OnceLock<Multimap> = OnceLock::new();
+
+    #[test]
+    fn request_signer_adds_mandatory_headers_and_authorization() {
+        let signer = RequestSigner::new();
+        let headers = signer.sign(base_opts("s3", Multimap::new()));
+
+        assert_eq!(
+            headers.get_vec(HOST).map(Vec::as_slice),
+            Some(&["localhost:9000".to_string()][..])
+        );
+        assert!(headers.contains_key(X_AMZ_DATE), "x-amz-date must be added");
+        assert_eq!(
+            headers.get_vec(X_AMZ_CONTENT_SHA256).map(Vec::as_slice),
+            Some(&[TEST_SHA256.to_string()][..])
+        );
+        let auth = headers
+            .get_vec("Authorization")
+            .expect("authorization header");
+        assert!(
+            auth[0].starts_with("AWS4-HMAC-SHA256 Credential="),
+            "auth: {}",
+            auth[0]
+        );
+    }
+
+    #[test]
+    fn request_signer_preserves_extra_headers() {
+        let signer = RequestSigner::new();
+        let mut extra = Multimap::new();
+        extra.add("content-type", "application/json");
+        let headers = signer.sign(base_opts("s3", extra));
+
+        assert_eq!(
+            headers.get_vec("content-type").map(Vec::as_slice),
+            Some(&["application/json".to_string()][..])
+        );
+        // content-type is folded into the signature's SignedHeaders list.
+        let auth = &headers.get_vec("Authorization").unwrap()[0];
+        assert!(
+            auth.contains("content-type"),
+            "signed headers must include content-type: {auth}"
+        );
+    }
+
+    #[test]
+    fn request_signer_scopes_by_service() {
+        let signer = RequestSigner::new();
+        let s3_auth = signer
+            .sign(base_opts("s3", Multimap::new()))
+            .get_vec("Authorization")
+            .unwrap()[0]
+            .clone();
+        let tables_auth = signer
+            .sign(base_opts("s3tables", Multimap::new()))
+            .get_vec("Authorization")
+            .unwrap()[0]
+            .clone();
+
+        assert!(
+            s3_auth.contains("/us-east-1/s3/aws4_request"),
+            "s3 scope: {s3_auth}"
+        );
+        assert!(
+            tables_auth.contains("/us-east-1/s3tables/aws4_request"),
+            "s3tables scope: {tables_auth}"
+        );
+        // Different service => different signature.
+        assert_ne!(s3_auth, tables_auth);
+    }
+
+    #[test]
+    fn request_signer_adds_session_token_header() {
+        let signer = RequestSigner::new();
+        let mut opts = base_opts("s3", Multimap::new());
+        opts.session_token = Some("SESSIONTOKEN123");
+        let headers = signer.sign(opts);
+
+        assert_eq!(
+            headers.get_vec(X_AMZ_SECURITY_TOKEN).map(Vec::as_slice),
+            Some(&["SESSIONTOKEN123".to_string()][..])
+        );
+    }
+
+    #[test]
+    fn request_signer_reuses_cache_deterministically() {
+        // Two signs with the same signer (shared cache) and identical inputs
+        // must produce identical signatures — exercises the reused cache path.
+        let signer = RequestSigner::new();
+        let a = signer
+            .sign(base_opts("s3", Multimap::new()))
+            .get_vec("Authorization")
+            .unwrap()[0]
+            .clone();
+        let b = signer
+            .sign(base_opts("s3", Multimap::new()))
+            .get_vec("Authorization")
+            .unwrap()[0]
+            .clone();
+        assert_eq!(a, b);
     }
 }

--- a/src/s3/signer.rs
+++ b/src/s3/signer.rs
@@ -347,6 +347,65 @@ pub(crate) fn sign_v4_s3(
     )
 }
 
+/// Signs an arbitrary HTTP request with AWS Signature V4 as service `"s3"` and
+/// returns the complete set of headers to send with it.
+///
+/// This is a self-contained entry point for signing requests to non-object S3
+/// APIs served on the same endpoint (for example the AIStor Memory API under
+/// `/_mem/v1`). Unlike [`sign_v4_s3`], it owns its signing-key cache and adds
+/// the mandatory `host`, `x-amz-date`, `x-amz-content-sha256` and (when a
+/// session token is supplied) `x-amz-security-token` headers before signing, so
+/// callers outside the SDK do not have to replicate the SDK's header prep.
+///
+/// - `method` / `path`: the request line; `path` is the URL-encoded path only.
+/// - `host`: the value for the `Host` header (e.g. `localhost:9000`).
+/// - `region`: the SigV4 credential-scope region.
+/// - `query_params`: canonicalized into the signature (may be empty).
+/// - `extra_headers`: additional headers to fold into the signature (e.g.
+///   `content-type`, `content-length`); may be empty.
+/// - `payload_sha256`: lowercase-hex SHA-256 of the request body. Use
+///   [`crate::s3::utils::EMPTY_SHA256`] for an empty body.
+///
+/// The returned [`Multimap`] contains every header (including the signed ones
+/// and the `Authorization` header) that must accompany the request.
+pub fn sign_v4_s3_request(
+    method: &Method,
+    host: &str,
+    path: &str,
+    region: &str,
+    query_params: &Multimap,
+    extra_headers: &Multimap,
+    access_key: &str,
+    secret_key: &str,
+    session_token: Option<&str>,
+    payload_sha256: &str,
+    date: UtcTime,
+) -> Multimap {
+    let mut headers = extra_headers.clone();
+    headers.add(HOST, host);
+    headers.add(X_AMZ_DATE, to_amz_date(date));
+    headers.add(X_AMZ_CONTENT_SHA256, payload_sha256);
+    if let Some(token) = session_token {
+        headers.add(X_AMZ_SECURITY_TOKEN, token);
+    }
+
+    let cache = RwLock::new(SigningKeyCache::new());
+    let region = Region::new(region.to_owned()).unwrap_or_default();
+    sign_v4_s3(
+        &cache,
+        method,
+        path,
+        &region,
+        &mut headers,
+        query_params,
+        access_key,
+        secret_key,
+        payload_sha256,
+        date,
+    );
+    headers
+}
+
 /// Signs and updates headers for the given request using a custom service type.
 ///
 /// Unlike [`sign_v4_s3`], which hardcodes the `"s3"` service, this allows signing

--- a/src/s3/signer.rs
+++ b/src/s3/signer.rs
@@ -363,20 +363,16 @@ pub struct SignRequestOptions<'a> {
     pub host: &'a str,
     /// URL-encoded request path only.
     pub path: &'a str,
-    /// SigV4 credential-scope region.
-    pub region: &'a str,
+    /// SigV4 credential-scope region (already validated by the caller).
+    pub region: &'a Region,
     /// Query parameters canonicalized into the signature (may be empty).
     pub query_params: &'a Multimap,
     /// Additional headers to fold into the signature (e.g. `content-type`,
     /// `content-length`); may be empty. Consumed and returned with the signed
-    /// headers added.
+    /// headers added. Any caller-supplied mandatory signing headers (`host`,
+    /// `x-amz-date`, `x-amz-content-sha256`, `x-amz-security-token`) are dropped
+    /// and replaced by the signer's own values, so they cannot be duplicated.
     pub extra_headers: Multimap,
-    /// Access key id.
-    pub access_key: &'a str,
-    /// Secret access key.
-    pub secret_key: &'a str,
-    /// Optional session token (STS temporary credentials).
-    pub session_token: Option<&'a str>,
     /// Lowercase-hex SHA-256 of the request body. Use
     /// [`crate::s3::utils::EMPTY_SHA256`] for an empty body.
     pub payload_sha256: &'a str,
@@ -384,56 +380,104 @@ pub struct SignRequestOptions<'a> {
     pub date: UtcTime,
 }
 
+/// Mandatory signing headers the signer always sets itself; any caller-supplied
+/// copies are stripped from `extra_headers` before signing so they appear
+/// exactly once and canonicalization matches transmission.
+const RESERVED_SIGNING_HEADERS: [&str; 4] =
+    [HOST, X_AMZ_DATE, X_AMZ_CONTENT_SHA256, X_AMZ_SECURITY_TOKEN];
+
 /// A reusable SigV4 request signer for non-object S3 APIs served on the same
 /// endpoint — for example the AIStor Memory API (`/_mem/v1`), the Tables/Iceberg
 /// REST catalog (`/_iceberg/v1`, service `s3tables`), or STS.
 ///
-/// Holds a signing-key cache that is **reused across calls**, so a caller that
-/// signs many requests (e.g. one signer per API client) amortizes the HMAC-SHA256
-/// key derivation. Construct one and keep it for the lifetime of the client.
+/// **Bound to one credential.** The signing-key cache is not keyed on the secret
+/// (by SDK design — see [`SigningKeyCache`]), so the signer carries the
+/// credential it signs with and reuses its cache safely across calls, amortizing
+/// the HMAC-SHA256 key derivation. Construct one per credential and keep it for
+/// the lifetime of the client; on credential rotation, create a new signer.
 ///
 /// [`sign`](RequestSigner::sign) adds the mandatory `host`, `x-amz-date`,
-/// `x-amz-content-sha256` and (when a session token is supplied)
-/// `x-amz-security-token` headers before signing, so callers outside the SDK do
-/// not replicate the SDK's header prep.
-#[derive(Debug, Default)]
+/// `x-amz-content-sha256` and (when a session token is set) `x-amz-security-token`
+/// headers before signing, so callers outside the SDK do not replicate the SDK's
+/// header prep.
 pub struct RequestSigner {
+    access_key: String,
+    secret_key: String,
+    session_token: Option<String>,
     cache: RwLock<SigningKeyCache>,
 }
 
+impl std::fmt::Debug for RequestSigner {
+    /// Redacts the secret key so it is never emitted in plaintext.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RequestSigner")
+            .field("access_key", &self.access_key)
+            .field("secret_key", &"<redacted>")
+            .field(
+                "session_token",
+                &self.session_token.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
+}
+
 impl RequestSigner {
-    /// Create a signer with a fresh signing-key cache.
+    /// Create a signer bound to the given credential, with a fresh signing-key
+    /// cache.
     #[must_use]
-    pub fn new() -> Self {
+    pub fn new(
+        access_key: impl Into<String>,
+        secret_key: impl Into<String>,
+        session_token: Option<String>,
+    ) -> Self {
         Self {
+            access_key: access_key.into(),
+            secret_key: secret_key.into(),
+            session_token,
             cache: RwLock::new(SigningKeyCache::new()),
         }
     }
 
     /// Sign a request and return every header (including the signed ones and the
     /// `Authorization` header) that must accompany it. Reuses this signer's
-    /// signing-key cache.
+    /// signing-key cache and credential.
     #[must_use]
     pub fn sign(&self, opts: SignRequestOptions<'_>) -> Multimap {
         let mut headers = opts.extra_headers;
+
+        // Drop any caller-supplied copies of the mandatory signing headers
+        // (case-insensitively) so the signer's own values are the only ones and
+        // canonicalization matches what is transmitted.
+        let reserved: Vec<String> = headers
+            .keys()
+            .filter(|k| {
+                RESERVED_SIGNING_HEADERS
+                    .iter()
+                    .any(|r| k.eq_ignore_ascii_case(r))
+            })
+            .cloned()
+            .collect();
+        for k in reserved {
+            headers.remove(&k);
+        }
+
         headers.add(HOST, opts.host);
         headers.add(X_AMZ_DATE, to_amz_date(opts.date));
         headers.add(X_AMZ_CONTENT_SHA256, opts.payload_sha256);
-        if let Some(token) = opts.session_token {
+        if let Some(token) = &self.session_token {
             headers.add(X_AMZ_SECURITY_TOKEN, token);
         }
 
-        let region = Region::new(opts.region.to_owned()).unwrap_or_default();
         sign_v4_with_service_type(
             &self.cache,
             opts.service,
             opts.method,
             opts.path,
-            &region,
+            opts.region,
             &mut headers,
             opts.query_params,
-            opts.access_key,
-            opts.secret_key,
+            &self.access_key,
+            &self.secret_key,
             opts.payload_sha256,
             opts.date,
         );
@@ -1604,18 +1648,23 @@ mod tests {
     const TEST_SECRET_KEY: &str = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
     const TEST_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
-    fn base_opts<'a>(service: &'a str, extra_headers: Multimap) -> SignRequestOptions<'a> {
+    fn test_signer() -> RequestSigner {
+        RequestSigner::new(TEST_ACCESS_KEY, TEST_SECRET_KEY, None)
+    }
+
+    fn base_opts<'a>(
+        service: &'a str,
+        region: &'a Region,
+        extra_headers: Multimap,
+    ) -> SignRequestOptions<'a> {
         SignRequestOptions {
             service,
             method: &Method::GET,
             host: "localhost:9000",
             path: "/_mem/v1/cortexes",
-            region: "us-east-1",
+            region,
             query_params: EMPTY_QUERY.get_or_init(Multimap::new),
             extra_headers,
-            access_key: TEST_ACCESS_KEY,
-            secret_key: TEST_SECRET_KEY,
-            session_token: None,
             payload_sha256: TEST_SHA256,
             date: get_test_date(),
         }
@@ -1626,8 +1675,9 @@ mod tests {
 
     #[test]
     fn request_signer_adds_mandatory_headers_and_authorization() {
-        let signer = RequestSigner::new();
-        let headers = signer.sign(base_opts("s3", Multimap::new()));
+        let region = Region::default();
+        let signer = test_signer();
+        let headers = signer.sign(base_opts("s3", &region, Multimap::new()));
 
         assert_eq!(
             headers.get_vec(HOST).map(Vec::as_slice),
@@ -1650,10 +1700,11 @@ mod tests {
 
     #[test]
     fn request_signer_preserves_extra_headers() {
-        let signer = RequestSigner::new();
+        let region = Region::default();
+        let signer = test_signer();
         let mut extra = Multimap::new();
         extra.add("content-type", "application/json");
-        let headers = signer.sign(base_opts("s3", extra));
+        let headers = signer.sign(base_opts("s3", &region, extra));
 
         assert_eq!(
             headers.get_vec("content-type").map(Vec::as_slice),
@@ -1668,15 +1719,47 @@ mod tests {
     }
 
     #[test]
+    fn request_signer_strips_caller_supplied_mandatory_headers() {
+        // A caller that already put host/x-amz-date/content-sha256 into
+        // extra_headers must not end up with duplicates: the signer replaces them.
+        let region = Region::default();
+        let signer = test_signer();
+        let mut extra = Multimap::new();
+        extra.add(HOST, "wrong-host:1");
+        extra.add(X_AMZ_DATE, "19700101T000000Z");
+        extra.add(X_AMZ_CONTENT_SHA256, "deadbeef");
+        extra.add("x-amz-date", "lowercase-variant"); // case-insensitive strip
+        let headers = signer.sign(base_opts("s3", &region, extra));
+
+        assert_eq!(
+            headers.get_vec(HOST).map(Vec::as_slice),
+            Some(&["localhost:9000".to_string()][..]),
+            "host must be replaced, not duplicated"
+        );
+        assert_eq!(
+            headers.get_vec(X_AMZ_CONTENT_SHA256).map(Vec::as_slice),
+            Some(&[TEST_SHA256.to_string()][..])
+        );
+        // Exactly one x-amz-date across any casing.
+        let date_count: usize = headers
+            .iter_all()
+            .filter(|(k, _)| k.eq_ignore_ascii_case(X_AMZ_DATE))
+            .map(|(_, v)| v.len())
+            .sum();
+        assert_eq!(date_count, 1, "x-amz-date must appear exactly once");
+    }
+
+    #[test]
     fn request_signer_scopes_by_service() {
-        let signer = RequestSigner::new();
+        let region = Region::default();
+        let signer = test_signer();
         let s3_auth = signer
-            .sign(base_opts("s3", Multimap::new()))
+            .sign(base_opts("s3", &region, Multimap::new()))
             .get_vec("Authorization")
             .unwrap()[0]
             .clone();
         let tables_auth = signer
-            .sign(base_opts("s3tables", Multimap::new()))
+            .sign(base_opts("s3tables", &region, Multimap::new()))
             .get_vec("Authorization")
             .unwrap()[0]
             .clone();
@@ -1695,10 +1778,13 @@ mod tests {
 
     #[test]
     fn request_signer_adds_session_token_header() {
-        let signer = RequestSigner::new();
-        let mut opts = base_opts("s3", Multimap::new());
-        opts.session_token = Some("SESSIONTOKEN123");
-        let headers = signer.sign(opts);
+        let region = Region::default();
+        let signer = RequestSigner::new(
+            TEST_ACCESS_KEY,
+            TEST_SECRET_KEY,
+            Some("SESSIONTOKEN123".into()),
+        );
+        let headers = signer.sign(base_opts("s3", &region, Multimap::new()));
 
         assert_eq!(
             headers.get_vec(X_AMZ_SECURITY_TOKEN).map(Vec::as_slice),
@@ -1707,20 +1793,41 @@ mod tests {
     }
 
     #[test]
-    fn request_signer_reuses_cache_deterministically() {
-        // Two signs with the same signer (shared cache) and identical inputs
-        // must produce identical signatures — exercises the reused cache path.
-        let signer = RequestSigner::new();
-        let a = signer
-            .sign(base_opts("s3", Multimap::new()))
+    fn request_signer_binds_credential_to_signature() {
+        // Two signers with different secrets over identical inputs must produce
+        // different signatures — credential identity is bound to the signer, so a
+        // shared cache can never sign with a stale secret.
+        let region = Region::default();
+        let a = RequestSigner::new(TEST_ACCESS_KEY, TEST_SECRET_KEY, None)
+            .sign(base_opts("s3", &region, Multimap::new()))
             .get_vec("Authorization")
             .unwrap()[0]
             .clone();
-        let b = signer
-            .sign(base_opts("s3", Multimap::new()))
+        let b = RequestSigner::new(TEST_ACCESS_KEY, "a-different-secret-key", None)
+            .sign(base_opts("s3", &region, Multimap::new()))
             .get_vec("Authorization")
             .unwrap()[0]
             .clone();
-        assert_eq!(a, b);
+        assert_ne!(a, b, "different secret must yield a different signature");
+    }
+
+    #[test]
+    fn request_signer_reuses_cached_signing_key() {
+        // The second sign with identical (date, region, service) must reuse the
+        // cached signing-key Arc rather than deriving a fresh one. Asserting via
+        // Arc::ptr_eq fails if it regresses to per-call derivation.
+        let region = Region::default();
+        let signer = test_signer();
+
+        let _ = signer.sign(base_opts("s3", &region, Multimap::new()));
+        let key_after_first = Arc::clone(&signer.cache.read().unwrap().key);
+
+        let _ = signer.sign(base_opts("s3", &region, Multimap::new()));
+        let key_after_second = Arc::clone(&signer.cache.read().unwrap().key);
+
+        assert!(
+            Arc::ptr_eq(&key_after_first, &key_after_second),
+            "second sign must reuse the cached signing key, not re-derive it"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Exposes public SigV4 request-signing helpers so external crates can sign
arbitrary requests to non-object S3 APIs served on the same endpoint (the AIStor
Memory API under `/_mem/v1` and the Tables/Iceberg REST catalog under
`/_iceberg/v1`). Previously the `sign_v4_*` functions were `pub(crate)`, so a
consumer had to re-implement SigV4 to talk to these APIs.

## What's added

- `sign_v4_s3_request(...)` — self-contained: owns its signing-key cache and adds
  the mandatory `host` / `x-amz-date` / `x-amz-content-sha256` (and
  `x-amz-security-token` when a session token is supplied) headers before signing,
  returning the complete header set. Signs as service `s3`.
- `sign_v4_service_request(service, ...)` — same, parameterized by service type
  (`s3tables` for the Iceberg REST catalog, `sts`, etc.); the service becomes part
  of the credential scope. `sign_v4_s3_request` now delegates to it with `s3`.

Both build on the existing internal `sign_v4_*` machinery — no new dependencies,
one SigV4 implementation.

## Motivation

`aimem` (the agent-native filesystem) needs to call the AIStor Memory API and
Tables API on the same endpoint as object I/O. These are not object APIs, so the
SDK's per-client signing path doesn't apply; a small public signing entrypoint
lets the client sign those REST requests with the same, proven SigV4 code rather
than a second implementation. Verified end-to-end against a live AIStor server
(cortex CRUD/secrets signed as `s3`; Iceberg catalog signed as `s3tables`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for signing non-object S3-compatible API requests using AWS Signature Version 4.
  * Introduced a reusable request-signing API that accepts consolidated signing options (service scope, method/host/path, query params, headers, credentials, timestamp, payload hash).
  * Automatically injects required authentication headers and includes session-token authentication when provided.
* **Tests**
  * Expanded unit tests to validate header injection/signed-headers behavior, service scoping differences, and deterministic reuse of signing-key caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->