### PR TITLE
rdma: send the descriptor as x-amz-rdma-token; drop the addr:size append

### DIFF
--- a/src/s3/rdma/protocol.rs
+++ b/src/s3/rdma/protocol.rs
@@ -173,21 +173,17 @@ fn http_client_for_token(token: &CStr) -> Arc<reqwest::Client> {
     }
 }
 
-fn format_rdma_token(token: &CStr, buf_addr: u64, size: u64) -> String {
-    let s = token.to_str().unwrap_or("");
-    format!("{s}:{buf_addr:016x}:{size:016x}")
-}
-
 /// Mirrors C++ `rdmaPut`: signs and issues the HTTP PUT control plane carrying
 /// the RDMA token, then parses the server reply.
 pub async fn rdma_put(
     client: &MinioClient,
     ctx: &mut S3RdmaClientCtx,
     token: &CStr,
-    buf_addr: u64,
     size: u64,
 ) -> isize {
-    let rdma_token = format_rdma_token(token, buf_addr, size);
+    // The token is the RDMA descriptor verbatim; its leading fields already
+    // carry the buffer address and transfer size, so it is sent as-is.
+    let rdma_token = token.to_str().unwrap_or("");
 
     let mut query_params = Multimap::default();
     if let Some(upload_id) = &ctx.upload_id {
@@ -313,10 +309,11 @@ pub async fn rdma_get(
     client: &MinioClient,
     ctx: &mut S3RdmaClientCtx,
     token: &CStr,
-    buf_addr: u64,
     size: u64,
 ) -> isize {
-    let rdma_token = format_rdma_token(token, buf_addr, size);
+    // The token is the RDMA descriptor verbatim; its leading fields already
+    // carry the buffer address and transfer size, so it is sent as-is.
+    let rdma_token = token.to_str().unwrap_or("");
 
     let query_params = Multimap::default();
     let url = match client.shared.base_url.build_url(
@@ -420,7 +417,7 @@ pub async fn rdma_put_with_retry(
             Some(t) => t,
             None => return RdmaOutcome::Failed,
         };
-        last = rdma_put(client, ctx, token.as_cstr(), buf_ptr as u64, size as u64).await;
+        last = rdma_put(client, ctx, token.as_cstr(), size as u64).await;
         drop(token);
         if last > 0 || last == RDMA_NOT_SUPPORTED {
             break;
@@ -443,7 +440,7 @@ pub async fn rdma_get_with_retry(
             Some(t) => t,
             None => return RdmaOutcome::Failed,
         };
-        last = rdma_get(client, ctx, token.as_cstr(), buf_ptr as u64, size as u64).await;
+        last = rdma_get(client, ctx, token.as_cstr(), size as u64).await;
         drop(token);
         if last > 0 || last == RDMA_NOT_SUPPORTED {
             break;

--- a/src/s3/rdma/protocol.rs
+++ b/src/s3/rdma/protocol.rs
@@ -174,7 +174,10 @@ fn http_client_for_token(token: &CStr) -> Arc<reqwest::Client> {
 }
 
 /// Mirrors C++ `rdmaPut`: signs and issues the HTTP PUT control plane carrying
-/// the RDMA token, then parses the server reply.
+/// the RDMA token, then parses the server reply. Uses the
+/// [PutObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html)
+/// request form, or [UploadPart](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html)
+/// when `ctx.upload_id` is set.
 pub async fn rdma_put(
     client: &MinioClient,
     ctx: &mut S3RdmaClientCtx,
@@ -305,6 +308,8 @@ pub async fn rdma_put(
 /// Mirrors C++ `rdmaGet`: signs and issues the HTTP GET control plane carrying
 /// the RDMA token, then trusts `x-amz-rdma-bytes-transferred` for the actual
 /// transferred byte count (which can be less than requested on ranged GETs).
+/// Uses the [GetObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html)
+/// request form.
 pub async fn rdma_get(
     client: &MinioClient,
     ctx: &mut S3RdmaClientCtx,

--- a/tests/start-server.sh
+++ b/tests/start-server.sh
@@ -7,7 +7,14 @@ set -e
 # extensions the integration tests exercise (RenameObject/RenamePrefix,
 # UpdateObjectEncryption, QoS, Inventory, LDAP STS).
 MINIO_IMAGE="registry.k5.min.dev/aistor/minio:edge"
-docker pull "${MINIO_IMAGE}"
+# Fall back to the public quay.io mirror when the private registry is
+# unreachable (e.g. fork-PR runners without access to registry.k5.min.dev).
+MINIO_IMAGE_FALLBACK="quay.io/minio/aistor/minio:edge-daily"
+if ! docker pull "${MINIO_IMAGE}"; then
+    echo "pull of ${MINIO_IMAGE} failed; falling back to ${MINIO_IMAGE_FALLBACK}" >&2
+    MINIO_IMAGE="${MINIO_IMAGE_FALLBACK}"
+    docker pull "${MINIO_IMAGE}"
+fi
 
 echo "MinIO Server Version:"
 docker run --rm "${MINIO_IMAGE}" --version


### PR DESCRIPTION
## What

`rdma_put`/`rdma_get` no longer append `:addr:size` to the RDMA token. The token from `cuMemObjGetRDMAToken` **is** the cuObject descriptor, whose leading fields already carry the buffer address and transfer size:
```
<addr:16>:<size:8>:<rkey:8>:<lid:4>:<qp:6>:<gid_present:1>:<gid:32>
```
Appending `:addr:size` merely duplicated fields 0 and 1, so `format_rdma_token` is removed, the descriptor is sent verbatim, and the unused `buf_addr` argument is dropped from `rdma_put`/`rdma_get`.

## Validation

Probed on a live mlx5 fabric (libcuobjclient 1.2.0), both GET and PUT:
```
token = "000073967e5ff000:00400000:01f2e973:0000:007a03:1:...ffff0f0f0fdf"
  field[0] == ptr  ? YES
  field[1] == size ? YES
```

`cargo check`, `cargo fmt --check`, `cargo clippy` all clean with `--features rdma`.

## Companion changes

Server reads addr/size from the descriptor's own fields (miniohq/aistor#6758, #6759). Also: minio-cpp#244, nixl ai-dynamo/nixl#1840. minio-go/minio-py inherit the fix through libminiocpp (no change needed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RDMA data transfers by preserving transfer tokens unchanged during PUT and GET operations.
  * Updated retry handling to use the correct token and transfer size information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->